### PR TITLE
update permission section

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,16 +291,6 @@ android {
 }
 ```
 
-### Add permissions to AndroidManifest.xml
-
-Add `INTERNET` permission to the app's manifest file.
-
-```xml
-<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
-<uses-permission android:name="android.permission.INTERNET"/>
-<uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
-```
-
 ### Config Android AssetLinks
 
 Configuring your Android `AssetLinks` is required for Magic Link authentication / Reset Password / Activate Account /

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,7 +1,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           xmlns:tools="http://schemas.android.com/tools"
           package="com.frontegg.reactnative">
-    <uses-permission android:name="android.permission.INTERNET"/>
+          
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
 
     <application>
 

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -1,8 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
-
     <application
       android:name=".MainApplication"
       android:label="@string/app_name"


### PR DESCRIPTION
We can add these permissions to the library module manifest file. So, we don't need to add them to the manifest of the application that we are integrating the library into.
Because when we build our application, all the manifests are merged into one, so we will have one file with all the permissions.
This will make library integration a little bit easier.
Another question about the permissions - POST_NOTIFICATIONS and ACCESS_NETWORK_STATE - do we really need them? Or if they are optional and not needed in all cases, then it is better to leave these two permissions in the integration guide and add a description of why each of them is worth adding.