### PR TITLE
fix(android): bump JVM target from 11 to 17

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -55,12 +55,12 @@ android {
   }
 
   compileOptions {
-    sourceCompatibility JavaVersion.VERSION_11
-    targetCompatibility JavaVersion.VERSION_11
+    sourceCompatibility JavaVersion.VERSION_17
+    targetCompatibility JavaVersion.VERSION_17
   }
 
   kotlinOptions {
-    jvmTarget = "11"
+    jvmTarget = "17"
   }
 }
 


### PR DESCRIPTION
## Summary

Bumps `sourceCompatibility` / `targetCompatibility` / `kotlinOptions.jvmTarget` in `android/build.gradle` from 11 to 17 so the library compiles against host apps using the modern React Native / AGP defaults.

## Problem

React Native 0.80+ projects compile host-app Java with JVM 17. AGP enforces JVM-target consistency between `compileDebugJavaWithJavac` and `compileDebugKotlin`, so any consumer on JVM 17 hits:

```
> Inconsistent JVM-target compatibility detected for tasks
> 'compileDebugJavaWithJavac' (17) and 'compileDebugKotlin' (11).
```

…on `:react-native_frontegg:compileDebugKotlin`. We've been carrying this as a `patch-package` patch on `@frontegg/react-native@1.2.16` to get the library to build at all.

## Compatibility note

JDK 17 has been the recommended Android Studio toolchain since Flamingo (April 2023) and is required by AGP 8.x. Host apps still on JDK 11 will need their AGP version to support `sourceCompatibility 17` (AGP 7.4+).

## Manual test plan

Reviewer / maintainer:

- [ ] On JDK 17 + AGP 8.x: `cd example/android && ./gradlew :react-native_frontegg:assembleDebug` succeeds. (Before this PR: fails with the JVM-target inconsistency error above.)
- [ ] On JDK 17 + AGP 8.x: `cd example/android && ./gradlew :app:assembleDebug` succeeds and the example app installs and launches.
- [ ] Existing E2E suite (`react-native-sdk-e2e.yml`) is green on this branch.

The fix is a 6-character config change with no runtime behavior, so unit-test coverage is not added; the gradle build is itself the test.

## Tested against (host side)

- React Native 0.80, AGP 8.x, JDK 17 — Healthie's app, multiple white-label flavors.

## Related

Part of a small batch of patches we discovered while integrating the SDK; the others are separate PRs (`currentActivity` deprecation, `BuildConfig` lookup).