### PR TITLE
fix(android): use reactApplicationContext.currentActivity

### DIFF
--- a/android/src/main/java/com/frontegg/reactnative/FronteggRNModule.kt
+++ b/android/src/main/java/com/frontegg/reactnative/FronteggRNModule.kt
@@ -119,7 +119,7 @@ class FronteggRNModule(val reactContext: ReactApplicationContext) :
 
   @ReactMethod
   fun login(loginHint: String?, promise: Promise) {
-    val activity = currentActivity
+    val activity = reactApplicationContext.currentActivity
     auth.login(activity!!, loginHint) {
       promise.resolve("")
     }
@@ -134,7 +134,7 @@ class FronteggRNModule(val reactContext: ReactApplicationContext) :
 
   @ReactMethod
   fun directLoginAction(type: String, data: String, ephemeralSession: Boolean, promise: Promise) {
-    val activity = currentActivity
+    val activity = reactApplicationContext.currentActivity
     auth.directLoginAction(activity!!, type, data)
     promise.resolve(true)
   }
@@ -147,7 +147,7 @@ class FronteggRNModule(val reactContext: ReactApplicationContext) :
 
   @ReactMethod
   fun loginWithPasskeys(promise: Promise) {
-    val activity = currentActivity
+    val activity = reactApplicationContext.currentActivity
     auth.loginWithPasskeys(activity!!) { error ->
       if (error != null) {
         promise.reject(error)
@@ -179,7 +179,7 @@ class FronteggRNModule(val reactContext: ReactApplicationContext) :
 
   @ReactMethod
   fun registerPasskeys(promise: Promise) {
-    val activity = currentActivity
+    val activity = reactApplicationContext.currentActivity
     auth.registerPasskeys(activity!!) { error ->
       if (error != null) {
         promise.reject(error)


### PR DESCRIPTION
## Summary

Replaces 4 uses of `currentActivity` in `FronteggRNModule.kt` with `reactApplicationContext.currentActivity`. Affected entry points: `login`, `directLoginAction`, `loginWithPasskeys`, `registerPasskeys`.

## Problem

`ReactContextBaseJavaModule.getCurrentActivity()` was made `protected` + `@Deprecated` in React Native 0.80, with the deprecation message recommending `reactApplicationContext.currentActivity` directly.

In Kotlin compiling against the updated Java stub, the inherited-Java-property shorthand `currentActivity` no longer resolves cleanly at the subclass level — depending on the Kotlin/RN toolchain versions you either get a compile error (`Cannot access 'getCurrentActivity': it is protected ...`) or a runtime NPE on the `auth.login(activity!!, ...)` site.

## Fix

Use the property the deprecation message points at. `reactApplicationContext` is already used elsewhere in the same file (`getName()`, the `auth` getter), so no new imports or fields needed.

## Compatibility

`reactApplicationContext.currentActivity` has been the public getter on `ReactApplicationContext` since RN 0.60+, so this change is functionally identical on every supported RN version.

## Manual test plan

Reviewer / maintainer:

- [ ] On RN 0.80+: example app compiles without the `Cannot access 'getCurrentActivity'` Kotlin error (before this PR: compile fails).
- [ ] On older RN (e.g. 0.74): `cd example && yarn start:android` still launches and login completes.
- [ ] Login flow exercises each affected entry point at least once:
  - [ ] `login()` — standard hosted login
  - [ ] `directLoginAction()` — social provider direct login (e.g. Google)
  - [ ] `loginWithPasskeys()` — passkey login
  - [ ] `registerPasskeys()` — passkey registration
- [ ] Existing E2E suite (`react-native-sdk-e2e.yml`) is green on this branch — covers the `login()` path.

The change is a property rename (one symbol → another, same return type and semantics), so unit-test coverage is not added; behavioural equivalence is best verified by exercising each entry point in the example app.

## Related

Part of a small batch we found while integrating the SDK — JVM 17 target and `BuildConfig` lookup are separate PRs.