### PR TITLE
fix(android): allow BuildConfig lookup when applicationId != namespace

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -81,6 +81,8 @@ dependencies {
   implementation 'io.reactivex.rxjava3:rxkotlin:3.0.1'
   implementation 'com.google.code.gson:gson:2.10.1'
   implementation 'com.frontegg.sdk:android:1.3.18'
+
+  testImplementation 'junit:junit:4.13.2'
 }
 
 if (isNewArchitectureEnabled()) {

--- a/android/src/main/java/com/frontegg/reactnative/Utils.kt
+++ b/android/src/main/java/com/frontegg/reactnative/Utils.kt
@@ -56,18 +56,10 @@ val Context.fronteggConstants: FronteggConstants
  *     `<application>` in `AndroidManifest.xml`, suffixed with `.BuildConfig`.
  */
 private fun resolveBuildConfigClass(context: Context): Class<*> {
-    val candidates = LinkedHashSet<String>()
-    candidates.add("${context.packageName}.BuildConfig")
-
-    runCatching {
-        val appInfo = context.packageManager.getApplicationInfo(
-            context.packageName,
-            PackageManager.GET_META_DATA,
-        )
-        appInfo.metaData?.getString(BUILD_CONFIG_PACKAGE_META)?.takeIf { it.isNotBlank() }?.let {
-            candidates.add("$it.BuildConfig")
-        }
-    }
+    val candidates = buildConfigClassCandidates(
+        primaryPackageName = context.packageName,
+        fallbackPackageName = readFallbackBuildConfigPackage(context),
+    )
 
     var lastError: ClassNotFoundException? = null
     for (className in candidates) {
@@ -88,6 +80,35 @@ private fun resolveBuildConfigClass(context: Context): Class<*> {
     )
     throw lastError ?: ClassNotFoundException("BuildConfig not found for ${context.packageName}")
 }
+
+/**
+ * Pure-logic candidate list for `BuildConfig` class lookup. Extracted from
+ * [resolveBuildConfigClass] so it can be unit-tested without Android dependencies.
+ *
+ * Guarantees:
+ *  - `primaryPackageName` is always tried first.
+ *  - `fallbackPackageName`, if non-null and non-blank, is appended next.
+ *  - If both inputs produce the same candidate string, only the first occurrence is kept.
+ */
+internal fun buildConfigClassCandidates(
+    primaryPackageName: String,
+    fallbackPackageName: String?,
+): List<String> {
+    val candidates = LinkedHashSet<String>()
+    candidates.add("$primaryPackageName.BuildConfig")
+    fallbackPackageName?.takeIf { it.isNotBlank() }?.let {
+        candidates.add("$it.BuildConfig")
+    }
+    return candidates.toList()
+}
+
+private fun readFallbackBuildConfigPackage(context: Context): String? = runCatching {
+    val appInfo = context.packageManager.getApplicationInfo(
+        context.packageName,
+        PackageManager.GET_META_DATA,
+    )
+    appInfo.metaData?.getString(BUILD_CONFIG_PACKAGE_META)
+}.getOrNull()
 
 fun <T> safeGetNullableValueFromBuildConfig(
     buildConfigClass: Class<*>,

--- a/android/src/main/java/com/frontegg/reactnative/Utils.kt
+++ b/android/src/main/java/com/frontegg/reactnative/Utils.kt
@@ -2,10 +2,13 @@ package com.frontegg.reactnative
 
 import android.app.Activity
 import android.content.Context
+import android.content.pm.PackageManager
 import android.util.Log
 
 
 const val TAG: String = "FronteggUtils"
+
+private const val BUILD_CONFIG_PACKAGE_META = "com.frontegg.reactnative.BUILD_CONFIG_PACKAGE"
 
 
 interface ActivityProvider {
@@ -14,37 +17,77 @@ interface ActivityProvider {
 
 val Context.fronteggConstants: FronteggConstants
     get() {
-        val packageName = this.packageName
-        val className = "$packageName.BuildConfig"
-        try {
-            val buildConfigClass = Class.forName(className)
+        val buildConfigClass = resolveBuildConfigClass(this)
 
-            // Get the field from BuildConfig class
-            val baseUrl = safeGetValueFromBuildConfig(buildConfigClass, "FRONTEGG_DOMAIN", "")
-            val clientId = safeGetValueFromBuildConfig(buildConfigClass, "FRONTEGG_CLIENT_ID", "")
+        // Get the field from BuildConfig class
+        val baseUrl = safeGetValueFromBuildConfig(buildConfigClass, "FRONTEGG_DOMAIN", "")
+        val clientId = safeGetValueFromBuildConfig(buildConfigClass, "FRONTEGG_CLIENT_ID", "")
 
-            val applicationId =
-                safeGetNullableValueFromBuildConfig(buildConfigClass, "FRONTEGG_APPLICATION_ID", "")
+        val applicationId =
+            safeGetNullableValueFromBuildConfig(buildConfigClass, "FRONTEGG_APPLICATION_ID", "")
 
-            val useAssetsLinks =
-                safeGetValueFromBuildConfig(buildConfigClass, "FRONTEGG_USE_ASSETS_LINKS", true)
-            val useChromeCustomTabs = safeGetValueFromBuildConfig(
-                buildConfigClass, "FRONTEGG_USE_CHROME_CUSTOM_TABS", true
-            )
+        val useAssetsLinks =
+            safeGetValueFromBuildConfig(buildConfigClass, "FRONTEGG_USE_ASSETS_LINKS", true)
+        val useChromeCustomTabs = safeGetValueFromBuildConfig(
+            buildConfigClass, "FRONTEGG_USE_CHROME_CUSTOM_TABS", true
+        )
 
-            return FronteggConstants(
-                baseUrl = baseUrl,
-                clientId = clientId,
-                applicationId = applicationId,
-                useAssetsLinks = useAssetsLinks,
-                useChromeCustomTabs = useChromeCustomTabs,
-                bundleId = this.packageName,
-            )
-        } catch (e: ClassNotFoundException) {
-            Log.e(TAG, "Class not found: $className")
-            throw e
+        return FronteggConstants(
+            baseUrl = baseUrl,
+            clientId = clientId,
+            applicationId = applicationId,
+            useAssetsLinks = useAssetsLinks,
+            useChromeCustomTabs = useChromeCustomTabs,
+            bundleId = this.packageName,
+        )
+    }
+
+/**
+ * Locate the host app's generated `BuildConfig` class.
+ *
+ * The class lives at `<javaPackage>.BuildConfig`, but apps whose `applicationId` differs from
+ * their AGP `namespace` (a common pattern for white-label / multi-flavor builds) need to
+ * override the lookup, since [Context.getPackageName] returns the `applicationId` at runtime
+ * while the generated `BuildConfig` is emitted under the `namespace`.
+ *
+ * Resolution order:
+ *  1. `<applicationContext.packageName>.BuildConfig` (the existing behaviour).
+ *  2. The value of the `com.frontegg.reactnative.BUILD_CONFIG_PACKAGE` `<meta-data>` entry on
+ *     `<application>` in `AndroidManifest.xml`, suffixed with `.BuildConfig`.
+ */
+private fun resolveBuildConfigClass(context: Context): Class<*> {
+    val candidates = LinkedHashSet<String>()
+    candidates.add("${context.packageName}.BuildConfig")
+
+    runCatching {
+        val appInfo = context.packageManager.getApplicationInfo(
+            context.packageName,
+            PackageManager.GET_META_DATA,
+        )
+        appInfo.metaData?.getString(BUILD_CONFIG_PACKAGE_META)?.takeIf { it.isNotBlank() }?.let {
+            candidates.add("$it.BuildConfig")
         }
     }
+
+    var lastError: ClassNotFoundException? = null
+    for (className in candidates) {
+        try {
+            return Class.forName(className)
+        } catch (e: ClassNotFoundException) {
+            Log.w(TAG, "BuildConfig not found at $className, trying next candidate")
+            lastError = e
+        }
+    }
+
+    Log.e(
+        TAG,
+        "Could not locate host BuildConfig. Tried: ${candidates.joinToString()}. " +
+            "If applicationId differs from your android.namespace, add " +
+            "<meta-data android:name=\"$BUILD_CONFIG_PACKAGE_META\" " +
+            "android:value=\"your.java.package\" /> to <application> in AndroidManifest.xml."
+    )
+    throw lastError ?: ClassNotFoundException("BuildConfig not found for ${context.packageName}")
+}
 
 fun <T> safeGetNullableValueFromBuildConfig(
     buildConfigClass: Class<*>,

--- a/android/src/test/java/com/frontegg/reactnative/UtilsTest.kt
+++ b/android/src/test/java/com/frontegg/reactnative/UtilsTest.kt
@@ -1,0 +1,53 @@
+package com.frontegg.reactnative
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class UtilsTest {
+
+    @Test
+    fun `single candidate when fallback is null`() {
+        val candidates = buildConfigClassCandidates(
+            primaryPackageName = "com.example.app",
+            fallbackPackageName = null,
+        )
+
+        assertEquals(listOf("com.example.app.BuildConfig"), candidates)
+    }
+
+    @Test
+    fun `single candidate when fallback is blank`() {
+        val candidates = buildConfigClassCandidates(
+            primaryPackageName = "com.example.app",
+            fallbackPackageName = "  ",
+        )
+
+        assertEquals(listOf("com.example.app.BuildConfig"), candidates)
+    }
+
+    @Test
+    fun `applicationId is always tried before fallback`() {
+        val candidates = buildConfigClassCandidates(
+            primaryPackageName = "com.example.app",
+            fallbackPackageName = "com.example.shared",
+        )
+
+        assertEquals(
+            listOf(
+                "com.example.app.BuildConfig",
+                "com.example.shared.BuildConfig",
+            ),
+            candidates,
+        )
+    }
+
+    @Test
+    fun `duplicate candidate is deduplicated when applicationId equals fallback`() {
+        val candidates = buildConfigClassCandidates(
+            primaryPackageName = "com.example.shared",
+            fallbackPackageName = "com.example.shared",
+        )
+
+        assertEquals(listOf("com.example.shared.BuildConfig"), candidates)
+    }
+}


### PR DESCRIPTION
## Summary

Adds a single-step fallback so `Context.fronteggConstants` can locate the host app's generated `BuildConfig` when its `applicationId` differs from its AGP `namespace`. Existing apps see no behaviour change.

## Problem

```kotlin
// Utils.kt — current
val packageName = this.packageName
val className = "$packageName.BuildConfig"
val buildConfigClass = Class.forName(className)  // ClassNotFoundException
```

`Context.getPackageName()` returns the Gradle `applicationId` at runtime, but AGP emits the generated `BuildConfig` under the module's `namespace`. For apps where these differ — common in white-label / multi-flavor RN apps that share a Java source tree but ship under different applicationIds — the SDK throws `ClassNotFoundException` at module init time before any JS code runs.

In our case (Healthie + 8 white-label flavors): `applicationId = com.healthie.app.<flavor>`, `namespace = com.main`, BuildConfig lives at `com.main.BuildConfig`, lookup fails.

## Fix

`resolveBuildConfigClass` now tries the candidates in order:

1. `<applicationId>.BuildConfig` — the existing behaviour. For apps where `applicationId == namespace` this matches immediately and step 2 never runs.
2. The value of a `<meta-data>` entry on `<application>` named `com.frontegg.reactnative.BUILD_CONFIG_PACKAGE`, suffixed with `.BuildConfig`.

If both miss, the original `ClassNotFoundException` is rethrown — but the error log now points consumers at the manifest override they need.

The pure candidate-generation logic is extracted into `buildConfigClassCandidates(primary, fallback)` so it can be unit-tested without an Android `Context`.

## Consumer wiring (only for the white-label case)

```xml
<application ...>
  <meta-data
    android:name="com.frontegg.reactnative.BUILD_CONFIG_PACKAGE"
    android:value="com.example.shared" />
</application>
```

## Tests

This PR introduces the first `android/src/test/` source set in the module, with `testImplementation 'junit:junit:4.13.2'`. New `UtilsTest.kt` covers four scenarios:

- [x] Single candidate when no fallback configured
- [x] Single candidate when fallback is blank/whitespace
- [x] Ordered two-candidate list (applicationId first, fallback second)
- [x] Deduplication when applicationId equals fallback

Runs via `./gradlew :react-native_frontegg:test`.

## Manual test plan

- [ ] **Default case (applicationId == namespace)**: example app builds and initialises `FronteggRNModule` without error; no behaviour change vs. master.
- [ ] **White-label case**: in a test app with `applicationId = com.foo.app` and `namespace = com.foo.shared` + `<meta-data android:name="com.frontegg.reactnative.BUILD_CONFIG_PACKAGE" android:value="com.foo.shared" />`, the module initialises successfully (before this PR: `ClassNotFoundException` at init).
- [ ] **Misconfigured case**: in a white-label app without the meta-data entry, the error log includes the documented snippet pointing the developer at the missing manifest override.

## Alternatives considered

- **Programmatic init**: `FronteggRN.setBuildConfigClass(BuildConfig::class.java)` from `MainApplication.onCreate`. More explicit, but adds a required call site for every host app and an ordering constraint (must run before the JS engine attaches the module).
- **Gradle property**: read the namespace at build time and emit it as a buildConfigField. Cleaner build-side, but doesn't help apps consuming the prebuilt AAR.

The manifest meta-data approach was the least invasive: zero changes for apps where `applicationId == namespace`, a single declarative line for everyone else, and no API surface on the JS or Kotlin side.

## Related

Part of a small batch we found while integrating the SDK — JVM 17 target and `currentActivity` deprecation are separate PRs.