### PR TITLE
Added ability to open admin portal.

### DIFF
--- a/FronteggRN.podspec
+++ b/FronteggRN.podspec
@@ -20,10 +20,10 @@ Pod::Spec.new do |s|
   # See https://github.com/facebook/react-native/blob/febf6b7f33fdb4904669f99d795eba4c0f95d7bf/scripts/cocoapods/new_architecture.rb#L79.
   if respond_to?(:install_modules_dependencies, true)
     install_modules_dependencies(s)
-    s.dependency "FronteggSwift", "1.2.76"
+    s.dependency "FronteggSwift", "1.3.10"
   else
     s.dependency "React-Core"
-    s.dependency "FronteggSwift", "1.2.76"
+    s.dependency "FronteggSwift", "1.3.10"
 
     # Don't install the dependencies when we run `pod install` in the old architecture.
     if ENV['RCT_NEW_ARCH_ENABLED'] == '1' then

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -80,7 +80,7 @@ dependencies {
   implementation "androidx.browser:browser:1.8.0"
   implementation 'io.reactivex.rxjava3:rxkotlin:3.0.1'
   implementation 'com.google.code.gson:gson:2.10.1'
-  implementation 'com.frontegg.sdk:android:1.3.18'
+  implementation 'com.frontegg.sdk:android:1.3.34'
 }
 
 if (isNewArchitectureEnabled()) {

--- a/android/src/main/java/com/frontegg/reactnative/FronteggRNModule.kt
+++ b/android/src/main/java/com/frontegg/reactnative/FronteggRNModule.kt
@@ -10,6 +10,7 @@ import com.facebook.react.bridge.ReactMethod
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.common.LifecycleState
 import com.facebook.react.modules.core.DeviceEventManagerModule
+import com.frontegg.android.AdminPortalActivity
 import com.frontegg.android.fronteggAuth
 import io.reactivex.rxjava3.core.Observable
 import io.reactivex.rxjava3.disposables.Disposable
@@ -187,6 +188,18 @@ class FronteggRNModule(val reactContext: ReactApplicationContext) :
         promise.resolve("")
       }
     }
+  }
+
+  @ReactMethod
+  fun openAdminPortal(promise: Promise) {
+    val activity = currentActivity
+    if (activity == null) {
+      promise.reject("NO_ACTIVITY", "Cannot open Admin Portal without an active Activity")
+      return
+    }
+
+    AdminPortalActivity.open(activity)
+    promise.resolve(null)
   }
 
   override fun getConstants(): MutableMap<String, Any?> = fronteggConstants.toMap()

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,6 +34,28 @@ For full documentation, visit the Frontegg Developer Portal:
 
 ---
 
+## 🔐 Native SDK versions
+
+The React Native wrapper depends on the underlying native SDKs:
+
+- On **Android**, the plugin and example app use `com.frontegg.sdk:android:1.3.34`.
+- On **iOS**, the plugin depends on `FronteggSwift` **1.3.10** via CocoaPods.
+
+After upgrading, run `pod install` in your iOS project and rebuild both platforms.
+
+---
+
+## 🔐 Native SDK versions
+
+The React Native wrapper depends on the underlying native SDKs:
+
+- On **Android**, the plugin and example app use `com.frontegg.sdk:android:1.3.34`.
+- On **iOS**, the plugin depends on `FronteggSwift` **1.3.10** via CocoaPods.
+
+After upgrading, run `pod install` in your iOS project and rebuild both platforms.
+
+---
+
 ## 🧑‍💻 Getting Started with Frontegg
 
 Don't have a Frontegg account yet?

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -3,3 +3,4 @@
 - [Setup Guide](setup.md)
 - [Usage Examples](usage.md)
 - [Advanced Topics](advanced.md)
+- [API Reference](api.md)

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -53,7 +53,7 @@ Passkeys provide a seamless, passwordless login experience using WebAuthn and pl
 
 1. **iOS Version**:  Ensure your project targets iOS 15 or later to support the necessary WebAuthn APIs.
 2. **Android**: Use Android SDK 26+.
-3. **Frontegg SDK Version**: Use Frontegg iOS SDK version 1.2.24 or later.
+3. **Frontegg SDK Version**: Use Frontegg iOS SDK version 1.3.10 or later.
 
 #### Android setup
 
@@ -63,7 +63,7 @@ Passkeys provide a seamless, passwordless login experience using WebAuthn and pl
    ```groovy
       dependencies {
        implementation 'androidx.browser:browser:1.8.0'
-       implementation 'com.frontegg.sdk:android:1.2.30'
+       implementation 'com.frontegg.sdk:android:1.3.34'
    }
    ```
 
@@ -132,3 +132,34 @@ async function handleLoginWithPasskeys() {
   }
 }
 ```
+
+## Admin Portal (Beta)
+
+The Admin Portal is a hosted page that lets end users manage their account, profile, sessions, and tenant settings. The React Native SDK exposes `openAdminPortal()` which delegates to the native SDKs:
+
+- **Android** — launches `AdminPortalActivity` (full-screen `WebView`)
+- **iOS** — presents `AdminPortalView` as a page sheet (`WKWebView`)
+
+The portal loads `${baseUrl}/oauth/portal?appId=<applicationId>` and shares the SDK session, so authenticated users are not asked to sign in again.
+
+> **Beta.** The API may change in future minor releases. Pin to an exact SDK version when embedding this in a shipping app.
+
+### Multi-app prerequisite
+
+For multi-app workspaces, configure `applicationId` in your native setup (see [Multi-app support](#multi-app-support)). Without `?appId=` the portal renders **"Application not found"** after sign-in.
+
+### Open the portal
+
+```tsx
+import { openAdminPortal } from '@frontegg/react-native';
+
+async function handleOpenAdminPortal() {
+  try {
+    await openAdminPortal();
+  } catch (error) {
+    console.error('Failed to open Admin Portal:', error);
+  }
+}
+```
+
+The portal is dismissed when the user swipes down (iOS) or taps the built-in close button. On Android, `window.close()` finishes the activity automatically.

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -125,7 +125,7 @@ android {
 dependencies {
     // The version of react-native is set by the React Native Gradle Plugin
     implementation("com.facebook.react:react-android")
-    implementation 'com.frontegg.sdk:android:1.3.18'
+    implementation 'com.frontegg.sdk:android:1.3.34'
     debugImplementation("com.facebook.flipper:flipper:${FLIPPER_VERSION}")
     debugImplementation("com.facebook.flipper:flipper-network-plugin:${FLIPPER_VERSION}") {
         exclude group:'com.squareup.okhttp3', module:'okhttp'

--- a/example/src/HomeScreen.tsx
+++ b/example/src/HomeScreen.tsx
@@ -12,6 +12,7 @@ import {
   registerPasskeys,
   loginWithPasskeys,
   requestAuthorize,
+  openAdminPortal,
 } from '@frontegg/react-native';
 import { useState } from 'react';
 import type { ITenantsResponse } from '@frontegg/rest-api';
@@ -78,6 +79,23 @@ export default function HomeScreen() {
             }}
           />
         </View>
+
+        {state.isAuthenticated ? (
+          <View style={styles.listenerButton}>
+            <FronteggButton
+              variant="primary"
+              title="Open Admin Portal"
+              accessibilityLabel="OpenAdminPortalButton"
+              onPress={async () => {
+                try {
+                  await openAdminPortal();
+                } catch (error) {
+                  console.error('Failed to open Admin Portal:', error);
+                }
+              }}
+            />
+          </View>
+        ) : null}
 
         {state.isAuthenticated ? (
           <View style={styles.listenerButton}>

--- a/example/src/components/FronteggButton.tsx
+++ b/example/src/components/FronteggButton.tsx
@@ -11,6 +11,7 @@ export type FronteggButtonProps = {
   variant?: ButtonVariant;
   style?: StyleProp<ViewStyle>;
   textStyle?: StyleProp<TextStyle>;
+  accessibilityLabel?: string;
 };
 
 const COLORS = {
@@ -29,6 +30,7 @@ export default function FronteggButton({
   variant = 'primary',
   style,
   textStyle,
+  accessibilityLabel,
 }: FronteggButtonProps) {
   const isOutline = variant === 'outline';
   const isDanger = variant === 'danger';
@@ -56,6 +58,7 @@ export default function FronteggButton({
   return (
     <Pressable
       accessibilityRole="button"
+      accessibilityLabel={accessibilityLabel}
       disabled={disabled}
       onPress={onPress}
       style={({ pressed }) => [

--- a/ios/FronteggRN.m
+++ b/ios/FronteggRN.m
@@ -44,4 +44,8 @@ RCT_EXTERN_METHOD(
                   resolver: (RCTPromiseResolveBlock)resolve
                   rejecter: (RCTPromiseRejectBlock)reject
                   )
+RCT_EXTERN_METHOD(
+                  openAdminPortal: (RCTPromiseResolveBlock)resolve
+                  rejecter: (RCTPromiseRejectBlock)reject
+                  )
 @end

--- a/ios/FronteggRN.swift
+++ b/ios/FronteggRN.swift
@@ -1,6 +1,8 @@
 import FronteggSwift
 import Foundation
 import Combine
+import SwiftUI
+import UIKit
 
 
 @objc(FronteggRN)
@@ -229,6 +231,45 @@ class FronteggRN: RCTEventEmitter {
             }
         }
         fronteggApp.auth.registerPasskeys(completion)
+    }
+
+    @objc
+    func openAdminPortal(
+        _ resolve: @escaping RCTPromiseResolveBlock,
+        rejecter: @escaping RCTPromiseRejectBlock
+    ) -> Void {
+        DispatchQueue.main.async {
+            guard let viewController = Self.topViewController() else {
+                rejecter(
+                    "NO_VIEW_CONTROLLER",
+                    "Cannot open Admin Portal without an active view controller",
+                    nil
+                )
+                return
+            }
+
+            if #available(iOS 14.0, *) {
+                let host = UIHostingController(rootView: AdminPortalView())
+                host.modalPresentationStyle = .pageSheet
+                viewController.present(host, animated: true)
+                resolve(nil)
+            } else {
+                rejecter("UNSUPPORTED", "Admin Portal requires iOS 14+", nil)
+            }
+        }
+    }
+
+    private static func topViewController() -> UIViewController? {
+        let keyWindow = UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .flatMap { $0.windows }
+            .first { $0.isKeyWindow }
+
+        var topController = keyWindow?.rootViewController
+        while let presented = topController?.presentedViewController {
+            topController = presented
+        }
+        return topController
     }
     
     // we need to override this method and

--- a/src/FronteggNative.ts
+++ b/src/FronteggNative.ts
@@ -72,6 +72,10 @@ export async function registerPasskeys(): Promise<void> {
   return FronteggRN.registerPasskeys();
 }
 
+export async function openAdminPortal(): Promise<void> {
+  return FronteggRN.openAdminPortal();
+}
+
 function debounce<T extends (...args: any[]) => any>(func: T, waitFor: number) {
   let timeout: any;
 

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -1,1 +1,24 @@
-it.todo('write a test');
+import { NativeModules } from 'react-native';
+import { openAdminPortal } from '../FronteggNative';
+
+jest.mock('react-native', () => ({
+  NativeModules: {
+    FronteggRN: {
+      openAdminPortal: jest.fn(() => Promise.resolve(null)),
+      subscribe: jest.fn(),
+    },
+  },
+  NativeEventEmitter: jest.fn().mockImplementation(() => ({
+    addListener: jest.fn(),
+  })),
+  Platform: {
+    select: jest.fn(),
+  },
+}));
+
+describe('openAdminPortal', () => {
+  it('calls the native openAdminPortal method', async () => {
+    await openAdminPortal();
+    expect(NativeModules.FronteggRN.openAdminPortal).toHaveBeenCalled();
+  });
+});

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -11,4 +11,5 @@ export {
   loginWithPasskeys,
   registerPasskeys,
   requestAuthorize,
+  openAdminPortal,
 } from './FronteggNative';


### PR DESCRIPTION
Bump frontegg-android-kotlin SDK to 1.3.34.
Bump frontegg-ios-swift SDK to 1.3.10.
Added openAdminPortal() API to open the embedded Admin Portal. Added "Open Admin Portal" button to all demo apps.