### PR TITLE
docs(android): declare applicationId before manifestPlaceholders in setup snippets

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -257,6 +257,11 @@ def fronteggClientId = "{{FRONTEGG_CLIENT_ID}}"
 
 android {
     defaultConfig {
+        // Keep your existing applicationId declared above manifestPlaceholders — the
+        // "package_name" placeholder below reads applicationId, so it must be set first.
+        // (If manifestPlaceholders is pasted above applicationId, package_name resolves
+        // to null and the AAR manifest merge fails.)
+        applicationId "com.your.company.app"
 
         manifestPlaceholders = [
                 "package_name" : applicationId,

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -18,11 +18,11 @@ def fronteggDomain = "{{FRONTEGG_BASE_URL}}" // without https://
 def fronteggClientId = "{{FRONTEGG_CLIENT_ID}}"
 ```
 
-3. Within the `android { defaultConfig { ... } }` section, add the following:
+3. Within the `android { defaultConfig { ... } }` section, **below your existing `applicationId` line**, add the following. The `package_name` placeholder reads `applicationId`, so `applicationId` must already be declared above it — otherwise it resolves to `null` and the AAR manifest merge fails:
 
 ```groovy
 manifestPlaceholders = [
-    "package_name"        : applicationId,
+    "package_name"        : applicationId,   // your app's applicationId (declared above)
     "frontegg_domain"     : fronteggDomain,
     "frontegg_client_id"  : fronteggClientId
 ]


### PR DESCRIPTION
## Problem

`docs/setup.md` and `docs/usage.md` show a `manifestPlaceholders` block to paste into `defaultConfig`:

```groovy
manifestPlaceholders = [
    "package_name": applicationId,
    ...
]
```

but neither shows `applicationId` declared above it. Groovy evaluates `defaultConfig { }` top-to-bottom, so when a customer pastes the block at the **top** of `defaultConfig` (before their `applicationId` line), `applicationId` resolves to `null`, the `package_name` placeholder is empty, and the **AAR manifest merge fails** — a common source of integration friction.

## Fix

Match the SDK's working example apps (`frontegg-android-kotlin` `app` / `embedded` / `applicationId` / `multi-region` build.gradle), which all declare `applicationId` first and then reference it in `manifestPlaceholders`:

- **setup.md** — show `applicationId` above `manifestPlaceholders`, with a comment explaining the ordering requirement.
- **usage.md** — instruct readers to add the block **below their existing `applicationId` line**, with an inline note on the `package_name` line.

Docs only — no behavioral change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)