### PR TITLE
fix(android): use reactApplicationContext.currentActivity in stepUp and openAdminPortal

### DIFF
--- a/android/src/main/java/com/frontegg/reactnative/FronteggRNModule.kt
+++ b/android/src/main/java/com/frontegg/reactnative/FronteggRNModule.kt
@@ -170,7 +170,7 @@ class FronteggRNModule(val reactContext: ReactApplicationContext) :
 
   @ReactMethod
   fun stepUp(maxAgeSeconds: Double, promise: Promise) {
-    val activity = currentActivity
+    val activity = reactApplicationContext.currentActivity
     if (activity == null) {
       promise.reject("NO_ACTIVITY", "Current activity is null")
       return
@@ -220,7 +220,7 @@ class FronteggRNModule(val reactContext: ReactApplicationContext) :
 
   @ReactMethod
   fun openAdminPortal(promise: Promise) {
-    val activity = currentActivity
+    val activity = reactApplicationContext.currentActivity
     if (activity == null) {
       promise.reject("NO_ACTIVITY", "Cannot open Admin Portal without an active Activity")
       return


### PR DESCRIPTION
PR #75 ("added uses of reactApplicationContext for activities") migrated the native module's activity lookups from the bare `currentActivity` to `reactApplicationContext.currentActivity`, but `stepUp` and `openAdminPortal` — added afterward in #73 and #78 — were missed and still used the bare reference, which fails to compile in consumer apps (reported on v1.2.17):

```
e: FronteggRNModule.kt:172:20 Unresolved reference 'currentActivity'
e: FronteggRNModule.kt:222:20 Unresolved reference 'currentActivity'
```

This aligns both call sites with the other four (`login`, `directLoginAction`, `loginWithPasskeys`, `registerPasskeys`), which already use `reactApplicationContext.currentActivity` and compile fine.

Needs a patch release (1.2.18) so the customer can pick it up.
