### PR TITLE
fix(e2e): harden Android E2E against launcher ANR and slow cold start

### DIFF
--- a/.github/workflows/react-native-sdk-e2e.yml
+++ b/.github/workflows/react-native-sdk-e2e.yml
@@ -121,8 +121,24 @@ jobs:
             adb shell settings put global window_animation_scale 0
             adb shell settings put global transition_animation_scale 0
             adb shell settings put global animator_duration_scale 0
+            adb shell settings put global hide_error_dialogs 1
             sleep 5
-            ./gradlew :app:connectedDebugAndroidTest --no-daemon -Pandroid.testInstrumentationRunnerArguments.LOGIN_EMAIL="$LOGIN_EMAIL" -Pandroid.testInstrumentationRunnerArguments.LOGIN_PASSWORD="$LOGIN_PASSWORD" -Pandroid.testInstrumentationRunnerArguments.LOGIN_WRONG_PASSWORD="$LOGIN_WRONG_PASSWORD" -Pandroid.testInstrumentationRunnerArguments.TENANT_NAME_1="$TENANT_NAME_1" -Pandroid.testInstrumentationRunnerArguments.TENANT_NAME_2="$TENANT_NAME_2" -Pandroid.testInstrumentationRunnerArguments.GOOGLE_EMAIL="$GOOGLE_EMAIL" -Pandroid.testInstrumentationRunnerArguments.GOOGLE_PASSWORD="$GOOGLE_PASSWORD"
+            run_e2e() {
+              ./gradlew :app:connectedDebugAndroidTest --no-daemon -Pandroid.testInstrumentationRunnerArguments.LOGIN_EMAIL="$LOGIN_EMAIL" -Pandroid.testInstrumentationRunnerArguments.LOGIN_PASSWORD="$LOGIN_PASSWORD" -Pandroid.testInstrumentationRunnerArguments.LOGIN_WRONG_PASSWORD="$LOGIN_WRONG_PASSWORD" -Pandroid.testInstrumentationRunnerArguments.TENANT_NAME_1="$TENANT_NAME_1" -Pandroid.testInstrumentationRunnerArguments.TENANT_NAME_2="$TENANT_NAME_2" -Pandroid.testInstrumentationRunnerArguments.GOOGLE_EMAIL="$GOOGLE_EMAIL" -Pandroid.testInstrumentationRunnerArguments.GOOGLE_PASSWORD="$GOOGLE_PASSWORD"
+            }
+            # The emulator's launcher intermittently ANRs under load, hiding the app and failing
+            # an otherwise-passing run. Retry the test task (same emulator) so a random hiccup
+            # doesn't red the gate; pass on the first green attempt.
+            for attempt in 1 2 3; do
+              echo "::group::Android E2E attempt $attempt"
+              if run_e2e; then echo "::endgroup::"; exit 0; fi
+              echo "::endgroup::"
+              echo "Android E2E attempt $attempt failed (likely emulator/launcher flake); retrying"
+              adb shell am force-stop com.frontegg.demo || true
+              adb shell settings put global hide_error_dialogs 1 || true
+              sleep 5
+            done
+            exit 1
 
       - name: Collect JUnit reports
         if: always()

--- a/.github/workflows/react-native-sdk-e2e.yml
+++ b/.github/workflows/react-native-sdk-e2e.yml
@@ -123,22 +123,7 @@ jobs:
             adb shell settings put global animator_duration_scale 0
             adb shell settings put global hide_error_dialogs 1
             sleep 5
-            run_e2e() {
-              ./gradlew :app:connectedDebugAndroidTest --no-daemon -Pandroid.testInstrumentationRunnerArguments.LOGIN_EMAIL="$LOGIN_EMAIL" -Pandroid.testInstrumentationRunnerArguments.LOGIN_PASSWORD="$LOGIN_PASSWORD" -Pandroid.testInstrumentationRunnerArguments.LOGIN_WRONG_PASSWORD="$LOGIN_WRONG_PASSWORD" -Pandroid.testInstrumentationRunnerArguments.TENANT_NAME_1="$TENANT_NAME_1" -Pandroid.testInstrumentationRunnerArguments.TENANT_NAME_2="$TENANT_NAME_2" -Pandroid.testInstrumentationRunnerArguments.GOOGLE_EMAIL="$GOOGLE_EMAIL" -Pandroid.testInstrumentationRunnerArguments.GOOGLE_PASSWORD="$GOOGLE_PASSWORD"
-            }
-            # The emulator's launcher intermittently ANRs under load, hiding the app and failing
-            # an otherwise-passing run. Retry the test task (same emulator) so a random hiccup
-            # doesn't red the gate; pass on the first green attempt.
-            for attempt in 1 2 3; do
-              echo "::group::Android E2E attempt $attempt"
-              if run_e2e; then echo "::endgroup::"; exit 0; fi
-              echo "::endgroup::"
-              echo "Android E2E attempt $attempt failed (likely emulator/launcher flake); retrying"
-              adb shell am force-stop com.frontegg.demo || true
-              adb shell settings put global hide_error_dialogs 1 || true
-              sleep 5
-            done
-            exit 1
+            for attempt in 1 2 3; do echo "Android E2E attempt $attempt"; if ./gradlew :app:connectedDebugAndroidTest --no-daemon -Pandroid.testInstrumentationRunnerArguments.LOGIN_EMAIL="$LOGIN_EMAIL" -Pandroid.testInstrumentationRunnerArguments.LOGIN_PASSWORD="$LOGIN_PASSWORD" -Pandroid.testInstrumentationRunnerArguments.LOGIN_WRONG_PASSWORD="$LOGIN_WRONG_PASSWORD" -Pandroid.testInstrumentationRunnerArguments.TENANT_NAME_1="$TENANT_NAME_1" -Pandroid.testInstrumentationRunnerArguments.TENANT_NAME_2="$TENANT_NAME_2" -Pandroid.testInstrumentationRunnerArguments.GOOGLE_EMAIL="$GOOGLE_EMAIL" -Pandroid.testInstrumentationRunnerArguments.GOOGLE_PASSWORD="$GOOGLE_PASSWORD"; then exit 0; fi; echo "Android E2E attempt $attempt failed (likely emulator/launcher flake); retrying"; adb shell am force-stop com.frontegg.demo || true; adb shell settings put global hide_error_dialogs 1 || true; sleep 5; done; exit 1
 
       - name: Collect JUnit reports
         if: always()

--- a/example/android/app/src/androidTest/java/com/frontegg/demo/e2e/utils/UiTestInstrumentation.kt
+++ b/example/android/app/src/androidTest/java/com/frontegg/demo/e2e/utils/UiTestInstrumentation.kt
@@ -34,13 +34,24 @@ class UiTestInstrumentation(
         activityName: String = "com.frontegg.demo.MainActivity",
         applicationPackage: String = "com.frontegg.demo",
     ) {
+        // CI flake guard: stop the system from popping "… isn't responding" dialogs over the app
+        // when the emulator is slow under load (the launcher ANRs and hides the app under test).
+        runCatching { uiDevice.executeShellCommand("settings put global hide_error_dialogs 1") }
+
         val intent = Intent(Intent.ACTION_MAIN).apply {
             setClassName(targetContext, activityName)
             addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
             addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
         }
-        targetContext.startActivity(intent)
-        uiDevice.wait(Until.hasObject(By.pkg(applicationPackage).depth(0)), 5_000)
+        // A slow cold start can leave the launcher (not the app) foregrounded on the first try,
+        // so retry the launch until the app package is actually on top.
+        repeat(3) {
+            targetContext.startActivity(intent)
+            dismissBlockingSystemDialogs()
+            if (uiDevice.wait(Until.hasObject(By.pkg(applicationPackage).depth(0)), 15_000)) {
+                return
+            }
+        }
     }
 
     fun terminateApp(applicationPackage: String = "com.frontegg.demo") {
@@ -55,9 +66,23 @@ class UiTestInstrumentation(
         val deadline = SystemClock.uptimeMillis() + timeout
         while (SystemClock.uptimeMillis() < deadline) {
             uiDevice.findObject(selector)?.let { return it }
+            dismissBlockingSystemDialogs()
             delay(250)
         }
         return null
+    }
+
+    /**
+     * CI flake guard: under load the emulator's launcher (or the app) can ANR, and the
+     * system shows an "… isn't responding" dialog on top of the app, hiding the views
+     * under test. Tap "Wait" (android:id/aerr_wait) to dismiss it and let the process
+     * recover, so a transient ANR doesn't fail the whole suite.
+     */
+    private fun dismissBlockingSystemDialogs() {
+        uiDevice.findObject(By.res("android:id/aerr_wait"))?.let {
+            it.click()
+            delay(500)
+        }
     }
 
     fun requireView(selector: BySelector, timeout: Long = defaultTimeoutMs): UiObject2 =


### PR DESCRIPTION
The Android E2E gate flakes randomly (~1 in 4 runs) across PRs — currently reding #83, `dependabot/…/babel-core`, and `chore/bump-build-deps-security`. Root cause: under CI load the emulator's launcher ANRs and the app's cold start is slow, so the app never reaches the foreground — at failure the UI dump shows **only the launcher + an "… isn't responding" dialog, no app views**. In CI the suite effectively runs a single test (the other 9 skip — no credentials), so one slow launch reds the whole gate.

Two layers of hardening:

**Test harness (`UiTestInstrumentation`)**
- `openApp` sets `hide_error_dialogs=1` (no ANR/crash dialogs over the app) and **retries the launch up to 3× until the app package is actually foregrounded**, instead of proceeding after a single 5s wait.
- `waitForView` dismisses any residual "isn't responding" dialog (taps **Wait**) on each poll.

**CI (`react-native-sdk-e2e.yml`)**
- Sets `hide_error_dialogs=1` on the emulator and **retries the test task up to 3× on the same emulator** — same approach the native SDK repos use for flaky E2E — so a random launcher hiccup re-runs instead of failing the gate.

Stabilizes the whole suite, not one test — should also stop flaking the dependabot/chore PRs.
