### PR TITLE
FR-24939 - chore(deps): bump native SDKs to Android 1.3.35 / iOS 1.3.11

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -86,7 +86,7 @@ dependencies {
   implementation "androidx.browser:browser:1.8.0"
   implementation 'io.reactivex.rxjava3:rxkotlin:3.0.1'
   implementation 'com.google.code.gson:gson:2.10.1'
-  implementation 'com.frontegg.sdk:android:1.3.34'
+  implementation 'com.frontegg.sdk:android:1.3.35'
   testImplementation "junit:junit:4.13.2"
 }
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,8 +38,8 @@ For full documentation, visit the Frontegg Developer Portal:
 
 The React Native wrapper depends on the underlying native SDKs:
 
-- On **Android**, the plugin and example app use `com.frontegg.sdk:android:1.3.34`.
-- On **iOS**, the plugin depends on `FronteggSwift` **1.3.10** via CocoaPods.
+- On **Android**, the plugin and example app use `com.frontegg.sdk:android:1.3.35`.
+- On **iOS**, the plugin depends on `FronteggSwift` **1.3.11** via CocoaPods.
 
 After upgrading, run `pod install` in your iOS project and rebuild both platforms.
 
@@ -49,8 +49,8 @@ After upgrading, run `pod install` in your iOS project and rebuild both platform
 
 The React Native wrapper depends on the underlying native SDKs:
 
-- On **Android**, the plugin and example app use `com.frontegg.sdk:android:1.3.34`.
-- On **iOS**, the plugin depends on `FronteggSwift` **1.3.10** via CocoaPods.
+- On **Android**, the plugin and example app use `com.frontegg.sdk:android:1.3.35`.
+- On **iOS**, the plugin depends on `FronteggSwift` **1.3.11** via CocoaPods.
 
 After upgrading, run `pod install` in your iOS project and rebuild both platforms.
 

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -53,7 +53,7 @@ Passkeys provide a seamless, passwordless login experience using WebAuthn and pl
 
 1. **iOS Version**:  Ensure your project targets iOS 15 or later to support the necessary WebAuthn APIs.
 2. **Android**: Use Android SDK 26+.
-3. **Frontegg SDK Version**: Use Frontegg iOS SDK version 1.3.10 or later.
+3. **Frontegg SDK Version**: Use Frontegg iOS SDK version 1.3.11 or later.
 
 #### Android setup
 
@@ -63,7 +63,7 @@ Passkeys provide a seamless, passwordless login experience using WebAuthn and pl
    ```groovy
       dependencies {
        implementation 'androidx.browser:browser:1.8.0'
-       implementation 'com.frontegg.sdk:android:1.3.34'
+       implementation 'com.frontegg.sdk:android:1.3.35'
    }
    ```
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -64,9 +64,9 @@ yarn ios --simulator "iPhone 17 Pro Max"
 
 If a physical iPhone is connected, React Native may target the device and fail on code signing (`com.your.bundle`). Use `--simulator` or disconnect the device.
 
-The `frontegg_spm` helper pins **FronteggSwift 1.3.10** from `https://github.com/frontegg/frontegg-ios-swift.git`, links it to the **FronteggRN** CocoaPods target, and configures the app Xcode project so SPM resolves without duplicate symbol errors at link time.
+The `frontegg_spm` helper pins **FronteggSwift 1.3.11** from `https://github.com/frontegg/frontegg-ios-swift.git`, links it to the **FronteggRN** CocoaPods target, and configures the app Xcode project so SPM resolves without duplicate symbol errors at link time.
 
-> **Embedded mode step-up:** `FronteggSwift` **1.3.10** routes `stepUp()` through the embedded `WKWebView` when `embeddedMode` is enabled (instead of `ASWebAuthenticationSession`), so MFA/step-up reuses the existing web session. Set `<key>embeddedMode</key><true/>` in `Frontegg.plist` if you use the embedded login box.
+> **Embedded mode step-up:** `FronteggSwift` **1.3.11** routes `stepUp()` through the embedded `WKWebView` when `embeddedMode` is enabled (instead of `ASWebAuthenticationSession`), so MFA/step-up reuses the existing web session. Set `<key>embeddedMode</key><true/>` in `Frontegg.plist` if you use the embedded login box.
 
 #### Step-up from JavaScript
 

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -132,7 +132,7 @@ android {
 dependencies {
     // The version of react-native is set by the React Native Gradle Plugin
     implementation("com.facebook.react:react-android")
-    implementation 'com.frontegg.sdk:android:1.3.34'
+    implementation 'com.frontegg.sdk:android:1.3.35'
     debugImplementation("com.facebook.flipper:flipper:${FLIPPER_VERSION}")
     debugImplementation("com.facebook.flipper:flipper-network-plugin:${FLIPPER_VERSION}") {
         exclude group:'com.squareup.okhttp3', module:'okhttp'

--- a/ios/Package.swift
+++ b/ios/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     ],
     products: [],
     dependencies: [
-        .package(url: "https://github.com/frontegg/frontegg-ios-swift.git", exact: "1.3.10"),
+        .package(url: "https://github.com/frontegg/frontegg-ios-swift.git", exact: "1.3.11"),
     ],
     targets: []
 )

--- a/ios/frontegg_spm.rb
+++ b/ios/frontegg_spm.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-# Links FronteggSwift (SPM 1.3.10) to the FronteggRN CocoaPods target after `pod install`.
+# Links FronteggSwift (SPM 1.3.11) to the FronteggRN CocoaPods target after `pod install`.
 # Patches Pods.xcodeproj/project.pbxproj as text — xcodeproj gem save() breaks Xcode 26.
 module FronteggSPM
   PACKAGE_URL = 'https://github.com/frontegg/frontegg-ios-swift.git'
-  PACKAGE_VERSION = '1.3.10'
+  PACKAGE_VERSION = '1.3.11'
   PRODUCT_NAME = 'FronteggSwift'
 
   PACKAGE_REF_ID = '2F0A5C48A15A74750BE517A0'


### PR DESCRIPTION
- Bump native SDKs: `frontegg-android-kotlin` **1.3.34 → 1.3.35**, `frontegg-ios-swift` (FronteggSwift) **1.3.10 → 1.3.11**.

What this picks up:

- Fixed: embedded step-up renders the MFA challenge instead of a blank page — the embedded login WebView exposes the native `getTokens` token bridge and a new step-up web driver routes the hosted login box to its step-up page, completing with an elevated (stepped-up) token. Requires hosted login box ≥ 7.118.0. (FR-24939)
- Fixed (iOS): step-up authorize URL emits OIDC-compliant integer `max_age`; connectivity observer stays alive across repeated offline/online cycles. (FR-25783)
- Fixed (Android): token refresh no longer stalls on short-TTL environments (refresh dedup keyed on token identity); deprecated `startActivityForResult` removed. (FR-19725)

All version references bumped: plugin + example app Gradle pins, SPM/CocoaPods manifests, and docs.

> Note: `com.frontegg.sdk:android:1.3.35` was released ~40 min ago and may still be syncing to Maven Central — if the Android CI job fails on dependency resolution, re-run it after sync.
