### PR TITLE
chore(deps): bump native SDKs to Android 1.3.36 / iOS 1.3.12

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -86,7 +86,7 @@ dependencies {
   implementation "androidx.browser:browser:1.8.0"
   implementation 'io.reactivex.rxjava3:rxkotlin:3.0.1'
   implementation 'com.google.code.gson:gson:2.10.1'
-  implementation 'com.frontegg.sdk:android:1.3.35'
+  implementation 'com.frontegg.sdk:android:1.3.36'
   testImplementation "junit:junit:4.13.2"
 }
 

--- a/ios/frontegg_spm.rb
+++ b/ios/frontegg_spm.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-# Links FronteggSwift (SPM 1.3.11) to the FronteggRN CocoaPods target after `pod install`.
+# Links FronteggSwift (SPM 1.3.12) to the FronteggRN CocoaPods target after `pod install`.
 # Patches Pods.xcodeproj/project.pbxproj as text — xcodeproj gem save() breaks Xcode 26.
 module FronteggSPM
   PACKAGE_URL = 'https://github.com/frontegg/frontegg-ios-swift.git'
-  PACKAGE_VERSION = '1.3.11'
+  PACKAGE_VERSION = '1.3.12'
   PRODUCT_NAME = 'FronteggSwift'
 
   PACKAGE_REF_ID = '2F0A5C48A15A74750BE517A0'


### PR DESCRIPTION
Bumps the bundled native SDK versions so the React Native wrapper picks up the July 2026 mobile-SDK audit fixes:

- **Android** `com.frontegg.sdk:android` 1.3.35 → **1.3.36**
- **iOS** FronteggSwift (SPM, via `ios/frontegg_spm.rb`) 1.3.11 → **1.3.12**

No wrapper API changes.