### PR TITLE
fix(react-native): await token refresh on Android instead of resolving stale (FR-25937)

### DIFF
--- a/android/src/main/java/com/frontegg/reactnative/FronteggRNModule.kt
+++ b/android/src/main/java/com/frontegg/reactnative/FronteggRNModule.kt
@@ -16,6 +16,9 @@ import com.frontegg.android.fronteggAuth
 import com.frontegg.android.models.Entitlement
 import io.reactivex.rxjava3.core.Observable
 import io.reactivex.rxjava3.disposables.Disposable
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import kotlin.time.DurationUnit
 import kotlin.time.toDuration
 
@@ -160,8 +163,17 @@ class FronteggRNModule(val reactContext: ReactApplicationContext) :
 
   @ReactMethod
   fun refreshToken(promise: Promise) {
-    auth.refreshTokenIfNeeded()
-    promise.resolve("")
+    // FR-25937: refreshTokenIfNeeded() starts the refresh in the background and returns
+    // immediately, so resolving here handed JS a stale token. refreshTokenAndWait() suspends
+    // until the refresh finishes; resolve its Boolean result to match iOS (which awaits a Bool).
+    CoroutineScope(Dispatchers.IO).launch {
+      try {
+        val success = auth.refreshTokenAndWait()
+        promise.resolve(success)
+      } catch (e: Exception) {
+        promise.reject("REFRESH_TOKEN_ERROR", e.message, e)
+      }
+    }
   }
 
   @ReactMethod


### PR DESCRIPTION
## FR-25937 — Android `refreshToken()` resolves before the refresh completes

`FronteggRNModule.refreshToken()` called `auth.refreshTokenIfNeeded()`, which starts the refresh in the background and returns immediately, then resolved `""`. Callers doing `await refreshToken(); read state.accessToken` therefore got a **stale** token. There was also a cross-platform shape mismatch — iOS awaits and resolves a `Bool`, Android resolved a string.

## Fix
Use the SDK's `suspend refreshTokenAndWait()` on `Dispatchers.IO` and resolve its `Boolean` result (rejecting on exception). This blocks until the refresh actually finishes and aligns the resolved shape with iOS.

## Verification
Compiles via the example-app Gradle harness (`:frontegg_react-native:compileDebugUnitTest`). The method itself isn't unit-testable in isolation (depends on the final `fronteggAuth` singleton, which can't be mocked in this toolchain).