### PR TITLE
fix(react-native): reject instead of crashing when no Activity on Android (FR-25939)

### DIFF
--- a/android/src/main/java/com/frontegg/reactnative/FronteggRNModule.kt
+++ b/android/src/main/java/com/frontegg/reactnative/FronteggRNModule.kt
@@ -1,5 +1,6 @@
 package com.frontegg.reactnative
 
+import android.app.Activity
 import android.os.Handler
 import android.os.Looper
 import com.facebook.react.bridge.Arguments
@@ -124,9 +125,10 @@ class FronteggRNModule(val reactContext: ReactApplicationContext) :
 
   @ReactMethod
   fun login(loginHint: String?, promise: Promise) {
-    val activity = reactApplicationContext.currentActivity
-    auth.login(activity!!, loginHint) {
-      promise.resolve("")
+    withActivityOrReject(reactApplicationContext.currentActivity, promise) { activity ->
+      auth.login(activity, loginHint) {
+        promise.resolve("")
+      }
     }
   }
 
@@ -145,7 +147,6 @@ class FronteggRNModule(val reactContext: ReactApplicationContext) :
     additionalQueryParams: ReadableMap?,
     promise: Promise
   ) {
-    val activity = reactApplicationContext.currentActivity
     // Parity note: the JS `directLoginAction(type, data, ephemeralSession, additionalQueryParams)`
     // signature is shared across platforms, so both trailing args must be declared here to keep the
     // JS↔native argument mapping aligned (otherwise `additionalQueryParams` collides with the
@@ -154,8 +155,10 @@ class FronteggRNModule(val reactContext: ReactApplicationContext) :
     // requires native support in frontegg-android-kotlin. Until then they are accepted no-ops on
     // Android. `ephemeralSession` is inherently iOS-only here (Android runs the flow in the embedded
     // WebView, not an ASWebAuthenticationSession-style browser session).
-    auth.directLoginAction(activity!!, type, data)
-    promise.resolve(true)
+    withActivityOrReject(reactApplicationContext.currentActivity, promise) { activity ->
+      auth.directLoginAction(activity, type, data)
+      promise.resolve(true)
+    }
   }
 
   @ReactMethod
@@ -166,12 +169,13 @@ class FronteggRNModule(val reactContext: ReactApplicationContext) :
 
   @ReactMethod
   fun loginWithPasskeys(promise: Promise) {
-    val activity = reactApplicationContext.currentActivity
-    auth.loginWithPasskeys(activity!!) { error ->
-      if (error != null) {
-        promise.reject(error)
-      } else {
-        promise.resolve("")
+    withActivityOrReject(reactApplicationContext.currentActivity, promise) { activity ->
+      auth.loginWithPasskeys(activity) { error ->
+        if (error != null) {
+          promise.reject(error)
+        } else {
+          promise.resolve("")
+        }
       }
     }
   }
@@ -223,12 +227,13 @@ class FronteggRNModule(val reactContext: ReactApplicationContext) :
 
   @ReactMethod
   fun registerPasskeys(promise: Promise) {
-    val activity = reactApplicationContext.currentActivity
-    auth.registerPasskeys(activity!!) { error ->
-      if (error != null) {
-        promise.reject(error)
-      } else {
-        promise.resolve("")
+    withActivityOrReject(reactApplicationContext.currentActivity, promise) { activity ->
+      auth.registerPasskeys(activity) { error ->
+        if (error != null) {
+          promise.reject(error)
+        } else {
+          promise.resolve("")
+        }
       }
     }
   }
@@ -274,4 +279,23 @@ class FronteggRNModule(val reactContext: ReactApplicationContext) :
     const val NAME = "FronteggRN"
 
   }
+}
+
+/**
+ * Runs [block] with the current [activity], or rejects [promise] with NO_ACTIVITY when it is null
+ * (FR-25939). login/directLoginAction/loginWithPasskeys/registerPasskeys previously used
+ * `currentActivity!!`, which threw a KotlinNullPointerException (crashing the app) when the app was
+ * backgrounded or the activity had been recreated. Top-level so it can be unit-tested without the
+ * ReactApplicationContext, matching stepUp/openAdminPortal which already null-check inline.
+ */
+internal inline fun withActivityOrReject(
+  activity: Activity?,
+  promise: Promise,
+  block: (Activity) -> Unit,
+) {
+  if (activity == null) {
+    promise.reject("NO_ACTIVITY", "Current activity is null")
+    return
+  }
+  block(activity)
 }

--- a/android/src/test/java/com/frontegg/reactnative/WithActivityOrRejectTest.kt
+++ b/android/src/test/java/com/frontegg/reactnative/WithActivityOrRejectTest.kt
@@ -1,0 +1,50 @@
+package com.frontegg.reactnative
+
+import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.WritableMap
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+/**
+ * FR-25939: login/directLoginAction/loginWithPasskeys/registerPasskeys used `currentActivity!!`,
+ * which throws KotlinNullPointerException (crashing the app) when the activity is null — e.g. the
+ * app is backgrounded or the activity was recreated. `withActivityOrReject` must instead reject the
+ * promise with NO_ACTIVITY and skip the block (matching stepUp/openAdminPortal, which already do so).
+ */
+class WithActivityOrRejectTest {
+
+    /** Records only the calls we assert on; the rest satisfy the Promise interface. */
+    private class RecordingPromise : Promise {
+        var rejectCode: String? = null
+        var resolved = false
+        override fun resolve(value: Any?) { resolved = true }
+        override fun reject(code: String, message: String?) { rejectCode = code }
+        override fun reject(code: String, throwable: Throwable?) { rejectCode = code }
+        override fun reject(code: String, message: String?, throwable: Throwable?) { rejectCode = code }
+        override fun reject(throwable: Throwable) { rejectCode = "throwable" }
+        override fun reject(throwable: Throwable, userInfo: WritableMap) { rejectCode = "throwable" }
+        override fun reject(code: String, userInfo: WritableMap) { rejectCode = code }
+        override fun reject(code: String, throwable: Throwable?, userInfo: WritableMap) { rejectCode = code }
+        override fun reject(code: String, message: String?, userInfo: WritableMap) { rejectCode = code }
+        override fun reject(code: String, message: String?, throwable: Throwable?, userInfo: WritableMap) { rejectCode = code }
+        @Deprecated("Deprecated in Java")
+        override fun reject(message: String) { rejectCode = message }
+    }
+
+    @Test
+    fun nullActivity_rejectsWithNoActivity_andSkipsBlock() {
+        val promise = RecordingPromise()
+        var blockRan = false
+
+        withActivityOrReject(null, promise) { blockRan = true }
+
+        assertFalse("the block must not run when no activity is attached", blockRan)
+        assertFalse("the promise must not be resolved when no activity is attached", promise.resolved)
+        assertEquals(
+            "must reject with NO_ACTIVITY rather than throw a KotlinNullPointerException",
+            "NO_ACTIVITY",
+            promise.rejectCode,
+        )
+    }
+}


### PR DESCRIPTION
## FR-25939 — Android `currentActivity!!` NPE crash

`login`, `directLoginAction`, `loginWithPasskeys` and `registerPasskeys` used `currentActivity!!`. When `currentActivity` is null (app backgrounded / activity recreated) this throws `KotlinNullPointerException` → **app crash** instead of a recoverable rejection. `stepUp` and `openAdminPortal` already null-check and `reject("NO_ACTIVITY", …)`.

## Fix
Extract a top-level `withActivityOrReject(activity, promise, block)` that rejects with `NO_ACTIVITY` and skips the block when the activity is null, and route the four remaining methods through it.

## Tests
`WithActivityOrRejectTest`: null activity → rejects `NO_ACTIVITY`, block not run, promise not resolved. **RED → GREEN** via the example-app Gradle harness (`:frontegg_react-native:testDebugUnitTest`).

## Note
The stale branch `fix/android-currentactivity-stepup-adminportal` (duplicates the already-merged stepUp/adminPortal fix and does not cover these four sites) can be deleted.