### PR TITLE
fix(react-native): cancel prior iOS Combine sinks before re-subscribing (FR-25940)

### DIFF
--- a/ios/FronteggRN.swift
+++ b/ios/FronteggRN.swift
@@ -34,9 +34,16 @@ class FronteggRN: RCTEventEmitter {
     }
     @objc
     func subscribe() -> [AnyHashable : Any]! {
-        
+
+        // FR-25940: cancel any prior subscriptions before re-subscribing. Each FronteggWrapper mount
+        // calls subscribe(), and without clearing, the two sinks below accumulated on `cancellables`
+        // on every call and were never cancelled (stopObserving only flips a flag) — so every state
+        // change fired N× duplicate native work. Mirrors Android, which disposes before re-subscribing.
+        cancellables.forEach { $0.cancel() }
+        cancellables.removeAll()
+
         let auth = fronteggApp.auth
-        
+
         var stateChange: AnyPublisher<Void, Never> {
             return Publishers.Merge5 (
                 auth.$refreshingToken.map { _ in },


### PR DESCRIPTION
## FR-25940 — iOS listener leak: `subscribe()` accumulates Combine sinks on every re-mount

Each `FronteggWrapper` mount calls `listener()` → `FronteggRN.subscribe()`. `subscribe()` added **two** new sinks to `cancellables` on every call and never cancelled them — `stopObserving()` only flips `hasListeners`. So N remounts meant N× duplicate native event work per state change, masked only by the 50 ms JS debounce. Android already disposes the prior subscription before re-subscribing.

## Fix
Cancel and clear `cancellables` at the start of `subscribe()`, mirroring Android's dispose-before-subscribe.

## Note
iOS-only; verified via `swiftc -parse`. Not compiled in a full iOS build here (no iOS build harness) — please let CI confirm.