### PR TITLE
fix(ios): reliable auth-event delivery — replay state on listener attach, dispose sinks on resubscribe (Android parity)

### DIFF
--- a/ios/FronteggRN.swift
+++ b/ios/FronteggRN.swift
@@ -23,10 +23,14 @@ class FronteggRN: RCTEventEmitter {
     }
     override func startObserving() {
         self.hasListeners = true
-        if(self.pendingObservingState){
-            self.pendingObservingState = false
-            self.sendEventToJS()
-        }
+        // Always replay the current auth state when a JS listener attaches,
+        // not only when a change was missed while unobserved. The JS-side
+        // state copy starts from a default and is only ever corrected by
+        // events; without an unconditional replay, a (re)subscribe that
+        // races a native state change leaves JS permanently stale (observed
+        // on-device: logout events lost during app-level teardown).
+        self.pendingObservingState = false
+        self.sendEventToJS()
     }
     
     override func stopObserving() {
@@ -34,7 +38,12 @@ class FronteggRN: RCTEventEmitter {
     }
     @objc
     func subscribe() -> [AnyHashable : Any]! {
-        
+
+        // Dispose previous sinks before resubscribing (parity with the
+        // Android module, which disposes before it resubscribes) so repeated
+        // subscribe() calls don't multiply event sends.
+        cancellables.removeAll()
+
         let auth = fronteggApp.auth
         
         var stateChange: AnyPublisher<Void, Never> {
@@ -82,7 +91,13 @@ class FronteggRN: RCTEventEmitter {
             }
             
         }).store(in: &cancellables)
-        
+
+        // Push the current state after (re)subscribing (Android parity) so a
+        // subscribe() call acts as an on-demand state resync for JS.
+        if(self.hasListeners){
+            self.sendEventToJS()
+        }
+
         return ["status": "OK"]
     }
     


### PR DESCRIPTION
## Problem

Two related event-delivery gaps in the iOS bridge (`ios/FronteggRN.swift`), both of which the **Android module already handles correctly**:

**1. State replay on listener attach is conditional.** `startObserving()` only replays the auth state if a change was missed while unobserved (`pendingObservingState`). The JS-side state copy starts from a default and is only ever corrected by events — so a (re)subscribe that races a native state change leaves JS **permanently stale**. We hit this on-device: a logout that coincided with app-level teardown never reached JS, `useAuth()` stayed `isAuthenticated: true` forever, and the next login's false→true transition detection broke. The failure is invisible from the app: nothing errors, JS just never hears about the state again.

**2. `subscribe()` never disposes previous sinks.** Each call adds another set of Combine subscriptions to `cancellables`, so repeated `subscribe()` calls multiply event sends. The Android module disposes its disposables before resubscribing and emits current state on subscribe; iOS does neither.

## Fix

- `startObserving()`: replay the current auth state unconditionally when a listener attaches.
- `subscribe()`: `cancellables.removeAll()` before resubscribing, and push the current state at the end — making `subscribe()` an on-demand state resync, matching Android.

No public API changes; behavior-only.

## Reproduction / validation

Reproduced on a real device (iPhone, iOS 18/26): trigger logout during app teardown (our repro used an app-level cleanup path that raced the auth-state emission) → JS never receives the unauthenticated event. With this patch the state replay on the next listener attach corrects JS immediately. We have been running these exact changes in production QA via patch-package since June across a 50-target white-label workspace.

<!-- MEDIA SLOT: optional screen recording — logout → relaunch showing JS stuck authenticated on stock vs. corrected with patch -->
