### PR TITLE
fix: make logout() awaitable on both platforms — resolve when the session actually ends

### DIFF
--- a/android/src/main/java/com/frontegg/reactnative/FronteggRNModule.kt
+++ b/android/src/main/java/com/frontegg/reactnative/FronteggRNModule.kt
@@ -108,8 +108,12 @@ class FronteggRNModule(val reactContext: ReactApplicationContext) :
   }
 
   @ReactMethod
-  fun logout() {
-    auth.logout()
+  fun logout(promise: Promise) {
+    // Resolve only after the SDK reports the logout finished, so JS can
+    // await the actual end of the session (parity with the iOS bridge).
+    auth.logout {
+      promise.resolve("Success")
+    }
   }
 
   @ReactMethod

--- a/ios/FronteggRN.m
+++ b/ios/FronteggRN.m
@@ -5,7 +5,10 @@
 @interface RCT_EXTERN_MODULE(FronteggRN, RCTEventEmitter)
 
 RCT_EXTERN_METHOD(subscribe)
-RCT_EXTERN_METHOD(logout)
+RCT_EXTERN_METHOD(
+                  logout: (RCTPromiseResolveBlock)resolve
+                  rejecter: (RCTPromiseRejectBlock)reject
+                  )
 RCT_EXTERN_METHOD(
                   login: (NSString *)loginHint
                   resolver: (RCTPromiseResolveBlock)resolve

--- a/ios/FronteggRN.swift
+++ b/ios/FronteggRN.swift
@@ -109,11 +109,29 @@ class FronteggRN: RCTEventEmitter {
     }
     
     @objc
-    func logout() -> [AnyHashable : Any]! {
-        DispatchQueue.main.sync {
-            fronteggApp.auth.logout()
+    func logout(_ resolve: @escaping RCTPromiseResolveBlock, rejecter: RCTPromiseRejectBlock) -> Void {
+        DispatchQueue.main.async {
+            // Use the completion overload so JS can await the actual end of
+            // the session, and push the final state when it lands. The
+            // fire-and-forget call relies solely on Combine-driven events,
+            // which can be lost when logout coincides with app-level
+            // teardown — leaving the JS state authenticated forever and
+            // breaking the next login's state-transition detection. The SDK
+            // completion is success-only, so there is no reject path.
+            self.fronteggApp.auth.logout { _ in
+                // Read/write hasListeners + pendingObservingState on main —
+                // RCTEventEmitter mutates them on main (start/stopObserving),
+                // so touching them off-main would be a data race.
+                DispatchQueue.main.async {
+                    if self.hasListeners {
+                        self.sendEventToJS()
+                    } else {
+                        self.pendingObservingState = true
+                    }
+                    resolve("Success")
+                }
+            }
         }
-        return ["status": "OK"]
     }
     
     @objc

--- a/src/FronteggNative.ts
+++ b/src/FronteggNative.ts
@@ -31,7 +31,7 @@ export function login(loginHint?: string) {
     });
 }
 
-export function logout() {
+export function logout(): Promise<void> {
   return FronteggRN.logout();
 }
 


### PR DESCRIPTION
## Problem

`logout()` is fire-and-forget on both platforms: the iOS bridge calls `auth.logout()` without the completion overload, and the Android bridge ignores the SDK's `callback` parameter. JS has no way to know when the session has actually ended and must rely solely on the auth-state event — which can be lost when logout coincides with app-level teardown (see #97 for the event-delivery half of this). The observed failure mode on-device: JS state stays authenticated forever after a logout, and the next login's state-transition detection never fires.

Both native SDKs already expose exactly the hook needed — iOS `FronteggAuth.logout(_ completion:)`, Android `logout(callback: () -> Unit)` — the bridge just doesn't use them. `login()` is already awaitable; `logout()` should be too.


https://github.com/user-attachments/assets/be2e08b1-9cfb-464e-8e2b-24f71cdacb13



## Fix

- **iOS**: promise-based bridge method using the completion overload; pushes the final auth state to JS (on main, respecting `RCTEventEmitter`'s threading of `hasListeners`/`pendingObservingState`) before resolving. `DispatchQueue.main.sync` → `async` (you can't block main waiting for an async completion).
- **Android**: `fun logout(promise: Promise)` resolving from the SDK callback.
- **JS**: `logout()` typed `Promise<void>`.

### Compatibility

`export function logout()` already `return`s the bridge call, so existing callers that ignore the return value are unaffected; callers can now `await` it. The iOS completion is success-only, so there is no reject path.

## Validation

Running in production QA via patch-package (iOS half) since June across a 50-target workspace: app-level logout flows `await logout()` and then tear down safely, with the final state event guaranteed delivered first. Android change compiles against `com.frontegg.sdk:android` 1.3.35 (callback parameter has a default, so the SDK call is source-compatible).

<!-- MEDIA SLOT: screen recording — logout → immediate re-login cycle completing cleanly (no stuck spinner / dead Sign-in) -->
