### PR TITLE
feat(ios): declare FronteggSwift via React Native's spm_dependency helper — unblocks multi-target (white-label) workspaces

### DIFF
--- a/FronteggRN.podspec
+++ b/FronteggRN.podspec
@@ -19,7 +19,24 @@ Pod::Spec.new do |s|
 
   # Use install_modules_dependencies helper to install the dependencies if React Native version >=0.71.0.
   # See https://github.com/facebook/react-native/blob/febf6b7f33fdb4904669f99d795eba4c0f95d7bf/scripts/cocoapods/new_architecture.rb#L79.
-  # FronteggSwift via SPM — linked in post_integrate by ios/frontegg_spm.rb (see docs/setup.md).
+  # FronteggSwift via SPM. On React Native >= 0.75 the official
+  # `spm_dependency` helper (react_native_pods.rb) declares the package here
+  # and `react_native_post_install` injects it into the Pods project for
+  # EVERY app target — no ID guessing, works for multi-target workspaces
+  # (white-label apps) where a single hardcoded-target script cannot.
+  # Keep the version in sync with ios/Package.swift.
+  # The `defined?` guard: autolinking evaluates this spec via `pod ipc spec`
+  # in a subprocess where react_native_pods.rb isn't loaded; the install-time
+  # evaluation (the one that matters) has the helper. On older RN without the
+  # helper, ios/frontegg_spm.rb (post_integrate) remains the fallback — see
+  # docs/setup.md.
+  if defined?(spm_dependency)
+    spm_dependency(s,
+      url: 'https://github.com/frontegg/frontegg-ios-swift.git',
+      requirement: { kind: 'exactVersion', version: '1.3.11' },
+      products: ['FronteggSwift']
+    )
+  end
 
   if respond_to?(:install_modules_dependencies, true)
     install_modules_dependencies(s)


### PR DESCRIPTION
## Problem

Since FronteggSwift went SPM-only (1.2.18+), `ios/frontegg_spm.rb` links it by text-patching the host app's `Pods.xcodeproj` with hardcoded object IDs sized for a single app target (+ test targets). Workspaces with **many app targets** can't use it: white-label products build dozens of apps from one workspace, and the script writes references for a target layout that doesn't match. That currently leaves multi-target consumers with no supported integration path.

<img width="1206" height="2622" alt="ios-launch-final-state" src="https://github.com/user-attachments/assets/2522f896-4de1-43e8-99d2-6ce623627415" />

## Fix

React Native ≥ 0.75 ships an official mechanism for exactly this case: [`spm_dependency`](https://github.com/facebook/react-native/blob/main/packages/react-native/scripts/cocoapods/spm.rb) declared in a **library podspec**, which `react_native_post_install` applies to every target consuming the pod — one `XCRemoteSwiftPackageReference` in the Pods project, no pbxproj text manipulation, no per-target work.

This PR declares FronteggSwift that way in `FronteggRN.podspec`:

- Guarded by `defined?(spm_dependency)` because autolinking evaluates the spec via `pod ipc spec` in a subprocess where `react_native_pods.rb` isn't loaded — the install-time evaluation (the one that matters) has the helper.
- On older RN without the helper, the guard makes this a no-op and `ios/frontegg_spm.rb` remains the documented fallback — no behavior change for existing consumers.
- Version pinned to match `ios/Package.swift` (1.3.11 at time of writing; comment notes to keep them in sync — you may prefer generating both from one source at release time).

## Validation

Validated on a production workspace with **~50 white-label app targets** (RN 0.81.5, CocoaPods static linkage):

- `pod install` injects a single package reference (`exactVersion`), applied by `react_native_post_install` — verified in the generated `Pods.xcodeproj`.
- **Debug and Release builds of two app targets with different team/bundle IDs succeed** with zero per-target configuration — the exact case the current script cannot handle.
- App boots through runtime init to the Frontegg embedded login page rendering in the SPM-delivered FronteggSwift WebView (screenshot below).
- Consumers can commit the workspace-level `Package.resolved` for revision-exact supply-chain pinning, equivalent to Podfile.lock checksums.

<!-- MEDIA SLOT: screenshot ios-launch-final-state.png (embedded login page rendered, SPM-linked build) + optional launch video -->
