### PR TITLE
fix(react-native): audit bug fixes FR-25937/38/39/40

### DIFF
--- a/android/src/main/java/com/frontegg/reactnative/FronteggRNModule.kt
+++ b/android/src/main/java/com/frontegg/reactnative/FronteggRNModule.kt
@@ -126,16 +126,16 @@ class FronteggRNModule(val reactContext: ReactApplicationContext) :
   @ReactMethod
   fun login(loginHint: String?, promise: Promise) {
     withActivityOrReject(reactApplicationContext.currentActivity, promise) { activity ->
-      auth.login(activity, loginHint) {
-        promise.resolve("")
+      auth.login(activity, loginHint) { error ->
+        resolveOrRejectLogin(error, promise)
       }
     }
   }
 
   @ReactMethod
   fun switchTenant(tenantId: String, promise: Promise) {
-    auth.switchTenant(tenantId) {
-      promise.resolve(tenantId)
+    auth.switchTenant(tenantId) { success ->
+      resolveTenantSwitch(success, tenantId, promise)
     }
   }
 
@@ -298,4 +298,30 @@ internal inline fun withActivityOrReject(
     return
   }
   block(activity)
+}
+
+/**
+ * Completes [promise] for the native login callback (FR-25938). The SDK callback is
+ * `((Exception?) -> Unit)?`; the module used to ignore the error and always resolve, so a
+ * cancelled/failed login looked like success to JS. Reject on a non-null [error], resolve otherwise.
+ */
+internal fun resolveOrRejectLogin(error: Exception?, promise: Promise) {
+  if (error != null) {
+    promise.reject("LOGIN_ERROR", error.message ?: "Login failed", error)
+  } else {
+    promise.resolve("")
+  }
+}
+
+/**
+ * Completes [promise] for the native switchTenant callback (FR-25938). The SDK callback yields a
+ * `Boolean`; the module used to ignore it and always resolve the tenant id, so a failed switch
+ * looked like success. Reject when [success] is false, otherwise resolve [tenantId].
+ */
+internal fun resolveTenantSwitch(success: Boolean, tenantId: String, promise: Promise) {
+  if (success) {
+    promise.resolve(tenantId)
+  } else {
+    promise.reject("SWITCH_TENANT_ERROR", "Failed to switch tenant")
+  }
 }

--- a/android/src/main/java/com/frontegg/reactnative/FronteggRNModule.kt
+++ b/android/src/main/java/com/frontegg/reactnative/FronteggRNModule.kt
@@ -1,5 +1,6 @@
 package com.frontegg.reactnative
 
+import android.app.Activity
 import android.os.Handler
 import android.os.Looper
 import com.facebook.react.bridge.Arguments
@@ -124,9 +125,10 @@ class FronteggRNModule(val reactContext: ReactApplicationContext) :
 
   @ReactMethod
   fun login(loginHint: String?, promise: Promise) {
-    val activity = reactApplicationContext.currentActivity
-    auth.login(activity!!, loginHint) {
-      promise.resolve("")
+    withActivityOrReject(reactApplicationContext.currentActivity, promise) { activity ->
+      auth.login(activity, loginHint) {
+        promise.resolve("")
+      }
     }
   }
 
@@ -145,7 +147,6 @@ class FronteggRNModule(val reactContext: ReactApplicationContext) :
     additionalQueryParams: ReadableMap?,
     promise: Promise
   ) {
-    val activity = reactApplicationContext.currentActivity
     // Parity note: the JS `directLoginAction(type, data, ephemeralSession, additionalQueryParams)`
     // signature is shared across platforms, so both trailing args must be declared here to keep the
     // JS↔native argument mapping aligned (otherwise `additionalQueryParams` collides with the
@@ -154,8 +155,10 @@ class FronteggRNModule(val reactContext: ReactApplicationContext) :
     // requires native support in frontegg-android-kotlin. Until then they are accepted no-ops on
     // Android. `ephemeralSession` is inherently iOS-only here (Android runs the flow in the embedded
     // WebView, not an ASWebAuthenticationSession-style browser session).
-    auth.directLoginAction(activity!!, type, data)
-    promise.resolve(true)
+    withActivityOrReject(reactApplicationContext.currentActivity, promise) { activity ->
+      auth.directLoginAction(activity, type, data)
+      promise.resolve(true)
+    }
   }
 
   @ReactMethod
@@ -166,12 +169,13 @@ class FronteggRNModule(val reactContext: ReactApplicationContext) :
 
   @ReactMethod
   fun loginWithPasskeys(promise: Promise) {
-    val activity = reactApplicationContext.currentActivity
-    auth.loginWithPasskeys(activity!!) { error ->
-      if (error != null) {
-        promise.reject(error)
-      } else {
-        promise.resolve("")
+    withActivityOrReject(reactApplicationContext.currentActivity, promise) { activity ->
+      auth.loginWithPasskeys(activity) { error ->
+        if (error != null) {
+          promise.reject(error)
+        } else {
+          promise.resolve("")
+        }
       }
     }
   }
@@ -223,12 +227,13 @@ class FronteggRNModule(val reactContext: ReactApplicationContext) :
 
   @ReactMethod
   fun registerPasskeys(promise: Promise) {
-    val activity = reactApplicationContext.currentActivity
-    auth.registerPasskeys(activity!!) { error ->
-      if (error != null) {
-        promise.reject(error)
-      } else {
-        promise.resolve("")
+    withActivityOrReject(reactApplicationContext.currentActivity, promise) { activity ->
+      auth.registerPasskeys(activity) { error ->
+        if (error != null) {
+          promise.reject(error)
+        } else {
+          promise.resolve("")
+        }
       }
     }
   }
@@ -274,4 +279,23 @@ class FronteggRNModule(val reactContext: ReactApplicationContext) :
     const val NAME = "FronteggRN"
 
   }
+}
+
+/**
+ * Runs [block] with the current [activity], or rejects [promise] with NO_ACTIVITY when it is null
+ * (FR-25939). login/directLoginAction/loginWithPasskeys/registerPasskeys previously used
+ * `currentActivity!!`, which threw a KotlinNullPointerException (crashing the app) when the app was
+ * backgrounded or the activity had been recreated. Top-level so it can be unit-tested without the
+ * ReactApplicationContext, matching stepUp/openAdminPortal which already null-check inline.
+ */
+internal inline fun withActivityOrReject(
+  activity: Activity?,
+  promise: Promise,
+  block: (Activity) -> Unit,
+) {
+  if (activity == null) {
+    promise.reject("NO_ACTIVITY", "Current activity is null")
+    return
+  }
+  block(activity)
 }

--- a/android/src/main/java/com/frontegg/reactnative/FronteggRNModule.kt
+++ b/android/src/main/java/com/frontegg/reactnative/FronteggRNModule.kt
@@ -16,6 +16,9 @@ import com.frontegg.android.fronteggAuth
 import com.frontegg.android.models.Entitlement
 import io.reactivex.rxjava3.core.Observable
 import io.reactivex.rxjava3.disposables.Disposable
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import kotlin.time.DurationUnit
 import kotlin.time.toDuration
 
@@ -160,8 +163,17 @@ class FronteggRNModule(val reactContext: ReactApplicationContext) :
 
   @ReactMethod
   fun refreshToken(promise: Promise) {
-    auth.refreshTokenIfNeeded()
-    promise.resolve("")
+    // FR-25937: refreshTokenIfNeeded() starts the refresh in the background and returns
+    // immediately, so resolving here handed JS a stale token. refreshTokenAndWait() suspends
+    // until the refresh finishes; resolve its Boolean result to match iOS (which awaits a Bool).
+    CoroutineScope(Dispatchers.IO).launch {
+      try {
+        val success = auth.refreshTokenAndWait()
+        promise.resolve(success)
+      } catch (e: Exception) {
+        promise.reject("REFRESH_TOKEN_ERROR", e.message, e)
+      }
+    }
   }
 
   @ReactMethod

--- a/android/src/test/java/com/frontegg/reactnative/AuthResultPropagationTest.kt
+++ b/android/src/test/java/com/frontegg/reactnative/AuthResultPropagationTest.kt
@@ -1,0 +1,67 @@
+package com.frontegg.reactnative
+
+import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.WritableMap
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * FR-25938: on Android, `login`'s callback ignored the `Exception?` arg and always resolved `""`,
+ * and `switchTenant` ignored the SDK callback's `Boolean` and always resolved the tenant id — so a
+ * cancelled login or a failed tenant switch looked like success to JS. The extracted helpers must
+ * reject on failure and resolve only on success.
+ */
+class AuthResultPropagationTest {
+
+    private class RecordingPromise : Promise {
+        var rejectCode: String? = null
+        var resolvedValue: Any? = null
+        var resolved = false
+        override fun resolve(value: Any?) { resolved = true; resolvedValue = value }
+        override fun reject(code: String, message: String?) { rejectCode = code }
+        override fun reject(code: String, throwable: Throwable?) { rejectCode = code }
+        override fun reject(code: String, message: String?, throwable: Throwable?) { rejectCode = code }
+        override fun reject(throwable: Throwable) { rejectCode = "throwable" }
+        override fun reject(throwable: Throwable, userInfo: WritableMap) { rejectCode = "throwable" }
+        override fun reject(code: String, userInfo: WritableMap) { rejectCode = code }
+        override fun reject(code: String, throwable: Throwable?, userInfo: WritableMap) { rejectCode = code }
+        override fun reject(code: String, message: String?, userInfo: WritableMap) { rejectCode = code }
+        override fun reject(code: String, message: String?, throwable: Throwable?, userInfo: WritableMap) { rejectCode = code }
+        @Deprecated("Deprecated in Java")
+        override fun reject(message: String) { rejectCode = message }
+    }
+
+    @Test
+    fun login_nullError_resolves() {
+        val promise = RecordingPromise()
+        resolveOrRejectLogin(null, promise)
+        assertEquals(true, promise.resolved)
+        assertNull(promise.rejectCode)
+    }
+
+    @Test
+    fun login_error_rejects_andDoesNotResolve() {
+        val promise = RecordingPromise()
+        resolveOrRejectLogin(RuntimeException("cancelled"), promise)
+        assertFalse("must not resolve on a login failure", promise.resolved)
+        assertEquals("LOGIN_ERROR", promise.rejectCode)
+    }
+
+    @Test
+    fun switchTenant_success_resolvesTenantId() {
+        val promise = RecordingPromise()
+        resolveTenantSwitch(true, "tenant-42", promise)
+        assertEquals("tenant-42", promise.resolvedValue)
+        assertNull(promise.rejectCode)
+    }
+
+    @Test
+    fun switchTenant_failure_rejects_andDoesNotResolve() {
+        val promise = RecordingPromise()
+        resolveTenantSwitch(false, "tenant-42", promise)
+        assertFalse("must not resolve when the tenant switch fails", promise.resolved)
+        assertEquals("SWITCH_TENANT_ERROR", promise.rejectCode)
+    }
+}

--- a/android/src/test/java/com/frontegg/reactnative/WithActivityOrRejectTest.kt
+++ b/android/src/test/java/com/frontegg/reactnative/WithActivityOrRejectTest.kt
@@ -1,0 +1,50 @@
+package com.frontegg.reactnative
+
+import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.WritableMap
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+/**
+ * FR-25939: login/directLoginAction/loginWithPasskeys/registerPasskeys used `currentActivity!!`,
+ * which throws KotlinNullPointerException (crashing the app) when the activity is null — e.g. the
+ * app is backgrounded or the activity was recreated. `withActivityOrReject` must instead reject the
+ * promise with NO_ACTIVITY and skip the block (matching stepUp/openAdminPortal, which already do so).
+ */
+class WithActivityOrRejectTest {
+
+    /** Records only the calls we assert on; the rest satisfy the Promise interface. */
+    private class RecordingPromise : Promise {
+        var rejectCode: String? = null
+        var resolved = false
+        override fun resolve(value: Any?) { resolved = true }
+        override fun reject(code: String, message: String?) { rejectCode = code }
+        override fun reject(code: String, throwable: Throwable?) { rejectCode = code }
+        override fun reject(code: String, message: String?, throwable: Throwable?) { rejectCode = code }
+        override fun reject(throwable: Throwable) { rejectCode = "throwable" }
+        override fun reject(throwable: Throwable, userInfo: WritableMap) { rejectCode = "throwable" }
+        override fun reject(code: String, userInfo: WritableMap) { rejectCode = code }
+        override fun reject(code: String, throwable: Throwable?, userInfo: WritableMap) { rejectCode = code }
+        override fun reject(code: String, message: String?, userInfo: WritableMap) { rejectCode = code }
+        override fun reject(code: String, message: String?, throwable: Throwable?, userInfo: WritableMap) { rejectCode = code }
+        @Deprecated("Deprecated in Java")
+        override fun reject(message: String) { rejectCode = message }
+    }
+
+    @Test
+    fun nullActivity_rejectsWithNoActivity_andSkipsBlock() {
+        val promise = RecordingPromise()
+        var blockRan = false
+
+        withActivityOrReject(null, promise) { blockRan = true }
+
+        assertFalse("the block must not run when no activity is attached", blockRan)
+        assertFalse("the promise must not be resolved when no activity is attached", promise.resolved)
+        assertEquals(
+            "must reject with NO_ACTIVITY rather than throw a KotlinNullPointerException",
+            "NO_ACTIVITY",
+            promise.rejectCode,
+        )
+    }
+}

--- a/ios/FronteggRN.swift
+++ b/ios/FronteggRN.swift
@@ -34,9 +34,16 @@ class FronteggRN: RCTEventEmitter {
     }
     @objc
     func subscribe() -> [AnyHashable : Any]! {
-        
+
+        // FR-25940: cancel any prior subscriptions before re-subscribing. Each FronteggWrapper mount
+        // calls subscribe(), and without clearing, the two sinks below accumulated on `cancellables`
+        // on every call and were never cancelled (stopObserving only flips a flag) — so every state
+        // change fired N× duplicate native work. Mirrors Android, which disposes before re-subscribing.
+        cancellables.forEach { $0.cancel() }
+        cancellables.removeAll()
+
         let auth = fronteggApp.auth
-        
+
         var stateChange: AnyPublisher<Void, Never> {
             return Publishers.Merge5 (
                 auth.$refreshingToken.map { _ in },

--- a/ios/FronteggRN.swift
+++ b/ios/FronteggRN.swift
@@ -119,17 +119,18 @@ class FronteggRN: RCTEventEmitter {
     @objc
     func login(
         _ loginHint: String?,
-        resolver: @escaping RCTPromiseResolveBlock, rejecter: RCTPromiseRejectBlock
+        resolver: @escaping RCTPromiseResolveBlock, rejecter: @escaping RCTPromiseRejectBlock
     ) -> Void {
-        
+
         DispatchQueue.main.sync {
             let completion: FronteggAuth.CompletionHandler = { result in
                 switch(result) {
                 case .success(_):
                     resolver("Success")
                 case .failure(let error):
-                    resolver("Failed: \(error.failureReason ?? "")")
-                    
+                    // FR-25938: previously resolved "Failed: …", so a cancelled/failed login looked
+                    // like success to JS. Reject so the awaited login() rejects.
+                    rejecter(error.failureReason, error.localizedDescription, error)
                 }
             }
             fronteggApp.auth.login(completion, loginHint:loginHint)
@@ -140,10 +141,17 @@ class FronteggRN: RCTEventEmitter {
     @objc
     func switchTenant(
         _ tenantId: String,
-        resolver: @escaping RCTPromiseResolveBlock, rejecter: RCTPromiseRejectBlock
+        resolver: @escaping RCTPromiseResolveBlock, rejecter: @escaping RCTPromiseRejectBlock
     ) -> Void {
-        fronteggApp.auth.switchTenant(tenantId: tenantId) { _ in
-            resolver(tenantId)
+        fronteggApp.auth.switchTenant(tenantId: tenantId) { result in
+            switch result {
+            case .success(_):
+                resolver(tenantId)
+            case .failure(let error):
+                // FR-25938: previously ignored the result and always resolved, so a failed switch
+                // looked like success.
+                rejecter(error.failureReason, error.localizedDescription, error)
+            }
         }
     }
     

--- a/src/FronteggNative.ts
+++ b/src/FronteggNative.ts
@@ -21,14 +21,11 @@ export function getConstants() {
   return FronteggRN.getConstants();
 }
 
-export function login(loginHint?: string) {
-  FronteggRN.login(loginHint)
-    .then((data: any) => {
-      console.log(data);
-    })
-    .catch((e: any) => {
-      console.log(e);
-    });
+export async function login(loginHint?: string): Promise<void> {
+  // FR-25938: previously fire-and-forget (swallowed the result in console.log), so callers could
+  // neither await completion nor observe a cancelled/failed login. Return the promise so it is
+  // awaitable and rejections propagate.
+  return FronteggRN.login(loginHint);
 }
 
 export function logout() {


### PR DESCRIPTION
## Combined React Native audit fixes

Consolidates the four RN audit-bug PRs into one (replaces #93, #94, #95, #96). The branches merged with **no conflicts** (#95 was already stacked on #94; #93 and #96 touch disjoint regions), and the merged result was re-verified end-to-end.

- **FR-25937** (High) — Android `refreshToken()` called `refreshTokenIfNeeded()` (returns immediately) then resolved `""` → stale token. Now uses the suspend `refreshTokenAndWait()` on `Dispatchers.IO` and resolves the `Boolean`, matching iOS.
- **FR-25939** (Medium) — `login`/`directLoginAction`/`loginWithPasskeys`/`registerPasskeys` used `currentActivity!!` → `KotlinNullPointerException` crash when null. Added top-level `withActivityOrReject(...)` that rejects `NO_ACTIVITY` instead.
- **FR-25938** (High) — `login`/`switchTenant` reported success on failure; JS `login()` was fire-and-forget. Added `resolveOrRejectLogin` / `resolveTenantSwitch` (Android), reject-on-failure (iOS `login`/`switchTenant`), and made JS `login()` return its promise (awaitable).
- **FR-25940** (Medium) — iOS `subscribe()` accumulated Combine sinks on every mount (never cancelled). Now clears `cancellables` before re-subscribing, mirroring Android.

## Verification
`:frontegg_react-native:testDebugUnitTest` green on the merged branch — `WithActivityOrRejectTest` (1), `AuthResultPropagationTest` (4), plus the existing `BuildConfigResolverTest` (5). iOS `swiftc -parse` clean; JS `tsc --noEmit` clean. iOS full build not run here (no iOS harness) — please let CI confirm.

_Supersedes #93 #94 #95 #96._