### PR TITLE
fix: awaitable logout() with always-settle timeout (both platforms)

### DIFF
--- a/android/src/main/java/com/frontegg/reactnative/FronteggRNModule.kt
+++ b/android/src/main/java/com/frontegg/reactnative/FronteggRNModule.kt
@@ -17,6 +17,7 @@ import com.frontegg.android.fronteggAuth
 import com.frontegg.android.models.Entitlement
 import io.reactivex.rxjava3.core.Observable
 import io.reactivex.rxjava3.disposables.Disposable
+import java.util.concurrent.atomic.AtomicBoolean
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -115,8 +116,23 @@ class FronteggRNModule(val reactContext: ReactApplicationContext) :
   fun logout(promise: Promise) {
     // Resolve only after the SDK reports the logout finished, so JS can
     // await the actual end of the session (parity with the iOS bridge).
+    //
+    // A timeout fallback guarantees the promise always settles, so
+    // `await logout()` can never hang if the SDK callback never fires
+    // (parity with the iOS bridge's 10s settle). `settled` (compare-and-set)
+    // guarantees we resolve exactly once — resolving a React Native Promise
+    // twice is an illegal callback invocation. The SDK callback may arrive on
+    // a background thread while the timeout runs on the main looper, so the
+    // guard must be atomic.
+    val settled = AtomicBoolean(false)
+    val settle = {
+      if (settled.compareAndSet(false, true)) {
+        promise.resolve("Success")
+      }
+    }
+    handler.postDelayed({ settle() }, LOGOUT_TIMEOUT_MS)
     auth.logout {
-      promise.resolve("Success")
+      settle()
     }
   }
 
@@ -294,6 +310,10 @@ class FronteggRNModule(val reactContext: ReactApplicationContext) :
   companion object {
     const val NAME = "FronteggRN"
 
+    // Fallback deadline for logout(): if the SDK completion never fires,
+    // resolve the promise anyway so `await logout()` cannot hang. Matches
+    // the iOS bridge's 10s settle.
+    private const val LOGOUT_TIMEOUT_MS = 10_000L
   }
 }
 

--- a/android/src/main/java/com/frontegg/reactnative/FronteggRNModule.kt
+++ b/android/src/main/java/com/frontegg/reactnative/FronteggRNModule.kt
@@ -112,8 +112,12 @@ class FronteggRNModule(val reactContext: ReactApplicationContext) :
   }
 
   @ReactMethod
-  fun logout() {
-    auth.logout()
+  fun logout(promise: Promise) {
+    // Resolve only after the SDK reports the logout finished, so JS can
+    // await the actual end of the session (parity with the iOS bridge).
+    auth.logout {
+      promise.resolve("Success")
+    }
   }
 
   @ReactMethod

--- a/ios/FronteggRN.m
+++ b/ios/FronteggRN.m
@@ -5,7 +5,10 @@
 @interface RCT_EXTERN_MODULE(FronteggRN, RCTEventEmitter)
 
 RCT_EXTERN_METHOD(subscribe)
-RCT_EXTERN_METHOD(logout)
+RCT_EXTERN_METHOD(
+                  logout: (RCTPromiseResolveBlock)resolve
+                  rejecter: (RCTPromiseRejectBlock)reject
+                  )
 RCT_EXTERN_METHOD(
                   login: (NSString *)loginHint
                   resolver: (RCTPromiseResolveBlock)resolve

--- a/ios/FronteggRN.swift
+++ b/ios/FronteggRN.swift
@@ -123,20 +123,29 @@ class FronteggRN: RCTEventEmitter {
             // fire-and-forget call relies solely on Combine-driven events,
             // which can be lost when logout coincides with app-level
             // teardown — leaving the JS state authenticated forever and
-            // breaking the next login's state-transition detection. The SDK
-            // completion is success-only, so there is no reject path.
-            self.fronteggApp.auth.logout { _ in
+            // breaking the next login's state-transition detection.
+            //
+            // `settle` runs once, on main. A timeout fallback guarantees the
+            // promise always settles so `await logout()` can never hang if the
+            // SDK completion never fires. The SDK completion is success-only,
+            // so settle resolves (never rejects), preserving Promise<void>.
+            var settled = false
+            let settle: () -> Void = {
+                guard !settled else { return }
+                settled = true
                 // Read/write hasListeners + pendingObservingState on main —
                 // RCTEventEmitter mutates them on main (start/stopObserving),
                 // so touching them off-main would be a data race.
-                DispatchQueue.main.async {
-                    if self.hasListeners {
-                        self.sendEventToJS()
-                    } else {
-                        self.pendingObservingState = true
-                    }
-                    resolve("Success")
+                if self.hasListeners {
+                    self.sendEventToJS()
+                } else {
+                    self.pendingObservingState = true
                 }
+                resolve("Success")
+            }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 10) { settle() }
+            self.fronteggApp.auth.logout { _ in
+                DispatchQueue.main.async { settle() }
             }
         }
     }

--- a/ios/FronteggRN.swift
+++ b/ios/FronteggRN.swift
@@ -116,11 +116,29 @@ class FronteggRN: RCTEventEmitter {
     }
     
     @objc
-    func logout() -> [AnyHashable : Any]! {
-        DispatchQueue.main.sync {
-            fronteggApp.auth.logout()
+    func logout(_ resolve: @escaping RCTPromiseResolveBlock, rejecter: RCTPromiseRejectBlock) -> Void {
+        DispatchQueue.main.async {
+            // Use the completion overload so JS can await the actual end of
+            // the session, and push the final state when it lands. The
+            // fire-and-forget call relies solely on Combine-driven events,
+            // which can be lost when logout coincides with app-level
+            // teardown — leaving the JS state authenticated forever and
+            // breaking the next login's state-transition detection. The SDK
+            // completion is success-only, so there is no reject path.
+            self.fronteggApp.auth.logout { _ in
+                // Read/write hasListeners + pendingObservingState on main —
+                // RCTEventEmitter mutates them on main (start/stopObserving),
+                // so touching them off-main would be a data race.
+                DispatchQueue.main.async {
+                    if self.hasListeners {
+                        self.sendEventToJS()
+                    } else {
+                        self.pendingObservingState = true
+                    }
+                    resolve("Success")
+                }
+            }
         }
-        return ["status": "OK"]
     }
     
     @objc

--- a/ios/FronteggRN.swift
+++ b/ios/FronteggRN.swift
@@ -23,10 +23,14 @@ class FronteggRN: RCTEventEmitter {
     }
     override func startObserving() {
         self.hasListeners = true
-        if(self.pendingObservingState){
-            self.pendingObservingState = false
-            self.sendEventToJS()
-        }
+        // Always replay the current auth state when a JS listener attaches, not
+        // only when a change was missed while unobserved. The JS-side state copy
+        // starts from a default and is only ever corrected by events; without an
+        // unconditional replay, a (re)subscribe that races a native state change
+        // leaves JS permanently stale (observed on-device: logout events lost
+        // during app-level teardown). Carried from #97.
+        self.pendingObservingState = false
+        self.sendEventToJS()
     }
     
     override func stopObserving() {

--- a/src/FronteggNative.ts
+++ b/src/FronteggNative.ts
@@ -28,7 +28,7 @@ export async function login(loginHint?: string): Promise<void> {
   return FronteggRN.login(loginHint);
 }
 
-export function logout() {
+export function logout(): Promise<void> {
   return FronteggRN.logout();
 }
 


### PR DESCRIPTION
## Summary

Makes `logout()` awaitable on both platforms **and** hardens it so `await logout()` can never hang.

Two layers:

1. **Awaitable logout (both platforms).** The bridge now resolves a promise from the native SDK's logout completion instead of being fire-and-forget, and `logout()` is typed `Promise<void>` in JS. This portion originates from external contribution #98 (Adam Rowe / Healthie) and is included here as the base.

2. **Always-settle timeout hardening (this PR's addition).** As submitted, the promise resolved *only* from the SDK completion callback — if that callback never fired, `await logout()` would hang forever. Both platforms now schedule a **10s fallback** and resolve exactly once:
   - **iOS** (`ios/FronteggRN.swift`): `settled` guard + `DispatchQueue.main.asyncAfter(deadline: .now() + 10)`.
   - **Android** (`FronteggRNModule.kt`): `handler.postDelayed(..., 10s)` + `AtomicBoolean.compareAndSet` guard (the SDK callback may land on a background thread while the timeout runs on the main looper, so the guard is atomic).

## Provenance / review note

The awaitable-logout base comes from a customer fork PR (#98). It was reviewed against the actual diff — no behavioral concerns beyond the hang risk, which this PR closes. Relates to #97 (auth-event delivery parity) and supersedes the Android/iOS halves of #98.

## Compatibility

`export function logout()` already returned the bridge call, so existing callers that ignore the return value are unaffected; callers can now `await` it. Completion is success-only on both SDKs, so there is no reject path — the promise always resolves.

## Validation

- Static review of threading and resolve-once semantics on both platforms.
- ⚠️ Not yet compiled in this environment (no Android/iOS toolchain available here) and no on-device run — please let CI + a device smoke test confirm before merge.

Files: `android/.../FronteggRNModule.kt`, `ios/FronteggRN.swift`, `ios/FronteggRN.m`, `src/FronteggNative.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)