### PR TITLE
feat(ios): declare FronteggSwift via spm_dependency (multi-target) — rebased, pinned 1.3.12

### DIFF
--- a/FronteggRN.podspec
+++ b/FronteggRN.podspec
@@ -33,7 +33,7 @@ Pod::Spec.new do |s|
   if defined?(spm_dependency)
     spm_dependency(s,
       url: 'https://github.com/frontegg/frontegg-ios-swift.git',
-      requirement: { kind: 'exactVersion', version: '1.3.11' },
+      requirement: { kind: 'exactVersion', version: '1.3.12' },
       products: ['FronteggSwift']
     )
   end

--- a/FronteggRN.podspec
+++ b/FronteggRN.podspec
@@ -19,7 +19,24 @@ Pod::Spec.new do |s|
 
   # Use install_modules_dependencies helper to install the dependencies if React Native version >=0.71.0.
   # See https://github.com/facebook/react-native/blob/febf6b7f33fdb4904669f99d795eba4c0f95d7bf/scripts/cocoapods/new_architecture.rb#L79.
-  # FronteggSwift via SPM — linked in post_integrate by ios/frontegg_spm.rb (see docs/setup.md).
+  # FronteggSwift via SPM. On React Native >= 0.75 the official
+  # `spm_dependency` helper (react_native_pods.rb) declares the package here
+  # and `react_native_post_install` injects it into the Pods project for
+  # EVERY app target — no ID guessing, works for multi-target workspaces
+  # (white-label apps) where a single hardcoded-target script cannot.
+  # Keep the version in sync with ios/Package.swift.
+  # The `defined?` guard: autolinking evaluates this spec via `pod ipc spec`
+  # in a subprocess where react_native_pods.rb isn't loaded; the install-time
+  # evaluation (the one that matters) has the helper. On older RN without the
+  # helper, ios/frontegg_spm.rb (post_integrate) remains the fallback — see
+  # docs/setup.md.
+  if defined?(spm_dependency)
+    spm_dependency(s,
+      url: 'https://github.com/frontegg/frontegg-ios-swift.git',
+      requirement: { kind: 'exactVersion', version: '1.3.11' },
+      products: ['FronteggSwift']
+    )
+  end
 
   if respond_to?(:install_modules_dependencies, true)
     install_modules_dependencies(s)

--- a/ios/Package.swift
+++ b/ios/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     ],
     products: [],
     dependencies: [
-        .package(url: "https://github.com/frontegg/frontegg-ios-swift.git", exact: "1.3.11"),
+        .package(url: "https://github.com/frontegg/frontegg-ios-swift.git", exact: "1.3.12"),
     ],
     targets: []
 )


### PR DESCRIPTION
## Summary

Recreates #99 as a Frontegg-owned branch, rebased on current `master` (post-#100), with the FronteggSwift SPM pin aligned to **1.3.12**.

Declares FronteggSwift via React Native's official `spm_dependency` helper (RN ≥ 0.75) so `react_native_post_install` injects the package into **every** app target — unblocking multi-target / white-label workspaces that the hardcoded-target `ios/frontegg_spm.rb` script can't handle. On older RN the `defined?(spm_dependency)` guard makes this a no-op and `frontegg_spm.rb` stays the documented fallback.

## Version alignment (resolves the #92 ↔ #99 conflict)

Original #99 pinned `1.3.11`. This bumps **both** the `spm_dependency` pin and `ios/Package.swift` (the reference manifest, whose comment says to keep them in sync) to **1.3.12**, matching #92's native bump. #92 still owns `ios/frontegg_spm.rb` + `android/build.gradle`, so there's **no file overlap** — and once both land, every iOS SPM path is on one version.

## Provenance

- `c0b078c` — the `spm_dependency` mechanism, authored by **@airowe** (cherry-picked from #99, which this closes).
- `0459d98` — version alignment to 1.3.12.

## Validation

Full CI runs here (the original #99 predated the Build / Lint | Typecheck / Unit-Test checks — it had only run E2E). Multi-target build behavior was validated on airowe's original PR (~50 white-label targets, RN 0.81.5, static CocoaPods linkage); please let CI confirm on this branch.

Supersedes #99.

🤖 Generated with [Claude Code](https://claude.com/claude-code)