### PR TITLE
feat: typed login() rejection shape across platforms (+ useAssetLinks plist passthrough docs/constant)

### DIFF
--- a/android/src/main/java/com/frontegg/reactnative/FronteggRNModule.kt
+++ b/android/src/main/java/com/frontegg/reactnative/FronteggRNModule.kt
@@ -13,8 +13,11 @@ import com.facebook.react.bridge.WritableMap
 import com.facebook.react.common.LifecycleState
 import com.facebook.react.modules.core.DeviceEventManagerModule
 import com.frontegg.android.AdminPortalActivity
+import com.frontegg.android.exceptions.CanceledByUserException
+import com.frontegg.android.exceptions.FailedToAuthenticateException
 import com.frontegg.android.fronteggAuth
 import com.frontegg.android.models.Entitlement
+import java.io.IOException
 import io.reactivex.rxjava3.core.Observable
 import io.reactivex.rxjava3.disposables.Disposable
 import java.util.concurrent.atomic.AtomicBoolean
@@ -340,13 +343,41 @@ internal inline fun withActivityOrReject(
  * Completes [promise] for the native login callback (FR-25938). The SDK callback is
  * `((Exception?) -> Unit)?`; the module used to ignore the error and always resolve, so a
  * cancelled/failed login looked like success to JS. Reject on a non-null [error], resolve otherwise.
+ *
+ * Issue #110: rejects with the stable cross-platform codes documented for the JS `login()`
+ * (see [normalizedLoginCode]); the raw platform details are preserved in the rejection's
+ * `userInfo` (`nativeCode` = exception class name, `nativeMessage` = exception message).
+ *
+ * [createMap] is injectable so JVM unit tests can substitute [Arguments.createMap], which
+ * requires the native RN libraries.
  */
-internal fun resolveOrRejectLogin(error: Exception?, promise: Promise) {
+internal fun resolveOrRejectLogin(
+  error: Exception?,
+  promise: Promise,
+  createMap: () -> WritableMap = Arguments::createMap,
+) {
   if (error != null) {
-    promise.reject("LOGIN_ERROR", error.message ?: "Login failed", error)
+    val userInfo = createMap().apply {
+      putString("nativeCode", error.javaClass.simpleName)
+      putString("nativeMessage", error.message)
+    }
+    promise.reject(normalizedLoginCode(error), error.message ?: "Login failed", error, userInfo)
   } else {
     promise.resolve("")
   }
+}
+
+/**
+ * Maps a login failure onto the stable, cross-platform rejection codes (issue #110). Keep in
+ * sync with `FronteggLoginErrorCode` in src/FronteggNative.ts and the iOS bridge. Mapping is
+ * conservative: only positively identified failures get a specific code; everything else is
+ * "unknown" with the raw exception preserved by the caller.
+ */
+internal fun normalizedLoginCode(error: Exception): String = when (error) {
+  is CanceledByUserException -> "user_cancelled"
+  is FailedToAuthenticateException -> "oauth_failed"
+  is IOException -> "network"
+  else -> "unknown"
 }
 
 /**

--- a/android/src/test/java/com/frontegg/reactnative/AuthResultPropagationTest.kt
+++ b/android/src/test/java/com/frontegg/reactnative/AuthResultPropagationTest.kt
@@ -1,7 +1,11 @@
 package com.frontegg.reactnative
 
+import com.facebook.react.bridge.JavaOnlyMap
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.WritableMap
+import com.frontegg.android.exceptions.CanceledByUserException
+import com.frontegg.android.exceptions.FailedToAuthenticateException
+import java.io.IOException
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
@@ -17,6 +21,7 @@ class AuthResultPropagationTest {
 
     private class RecordingPromise : Promise {
         var rejectCode: String? = null
+        var rejectUserInfo: WritableMap? = null
         var resolvedValue: Any? = null
         var resolved = false
         override fun resolve(value: Any?) { resolved = true; resolvedValue = value }
@@ -25,18 +30,22 @@ class AuthResultPropagationTest {
         override fun reject(code: String, message: String?, throwable: Throwable?) { rejectCode = code }
         override fun reject(throwable: Throwable) { rejectCode = "throwable" }
         override fun reject(throwable: Throwable, userInfo: WritableMap) { rejectCode = "throwable" }
-        override fun reject(code: String, userInfo: WritableMap) { rejectCode = code }
-        override fun reject(code: String, throwable: Throwable?, userInfo: WritableMap) { rejectCode = code }
-        override fun reject(code: String, message: String?, userInfo: WritableMap) { rejectCode = code }
-        override fun reject(code: String, message: String?, throwable: Throwable?, userInfo: WritableMap) { rejectCode = code }
+        override fun reject(code: String, userInfo: WritableMap) { rejectCode = code; rejectUserInfo = userInfo }
+        override fun reject(code: String, throwable: Throwable?, userInfo: WritableMap) { rejectCode = code; rejectUserInfo = userInfo }
+        override fun reject(code: String, message: String?, userInfo: WritableMap) { rejectCode = code; rejectUserInfo = userInfo }
+        override fun reject(code: String, message: String?, throwable: Throwable?, userInfo: WritableMap) { rejectCode = code; rejectUserInfo = userInfo }
         @Deprecated("Deprecated in Java")
         override fun reject(message: String) { rejectCode = message }
     }
 
+    /** JavaOnlyMap is RN's pure-JVM WritableMap; Arguments.createMap needs native libs. */
+    private fun rejectLogin(error: Exception?, promise: Promise) =
+        resolveOrRejectLogin(error, promise) { JavaOnlyMap() }
+
     @Test
     fun login_nullError_resolves() {
         val promise = RecordingPromise()
-        resolveOrRejectLogin(null, promise)
+        rejectLogin(null, promise)
         assertEquals(true, promise.resolved)
         assertNull(promise.rejectCode)
     }
@@ -44,9 +53,36 @@ class AuthResultPropagationTest {
     @Test
     fun login_error_rejects_andDoesNotResolve() {
         val promise = RecordingPromise()
-        resolveOrRejectLogin(RuntimeException("cancelled"), promise)
+        rejectLogin(RuntimeException("boom"), promise)
         assertFalse("must not resolve on a login failure", promise.resolved)
-        assertEquals("LOGIN_ERROR", promise.rejectCode)
+        assertEquals("unknown", promise.rejectCode)
+    }
+
+    // Issue #110: login() rejects with stable, cross-platform codes; the raw platform
+    // details ride along in userInfo (nativeCode = exception class name).
+    @Test
+    fun login_cancelledByUser_rejectsWithUserCancelled() {
+        val promise = RecordingPromise()
+        rejectLogin(CanceledByUserException(), promise)
+        assertEquals("user_cancelled", promise.rejectCode)
+        assertEquals(
+            "CanceledByUserException",
+            (promise.rejectUserInfo as JavaOnlyMap).getString("nativeCode")
+        )
+    }
+
+    @Test
+    fun login_failedToAuthenticate_rejectsWithOauthFailed() {
+        val promise = RecordingPromise()
+        rejectLogin(FailedToAuthenticateException(error = "bad code"), promise)
+        assertEquals("oauth_failed", promise.rejectCode)
+    }
+
+    @Test
+    fun login_ioException_rejectsWithNetwork() {
+        val promise = RecordingPromise()
+        rejectLogin(IOException("timeout"), promise)
+        assertEquals("network", promise.rejectCode)
     }
 
     @Test

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -104,6 +104,16 @@ See the [example `HomeScreen`](https://github.com/frontegg/frontegg-react-native
 - Replace `{{FRONTEGG_BASE_URL}}` with the domain name from your Frontegg Portal.
 - Replace `{{FRONTEGG_CLIENT_ID}}` with your Frontegg client ID.
 
+> **Plist keys are forwarded as-is.** iOS configuration is plist-driven: the native
+> `FronteggSwift` SDK reads `Frontegg.plist` directly, so every key you set there reaches the
+> native SDK without any wrapper involvement. In particular, the proposed
+> `<key>useAssetLinks</key><true/>` option
+> ([frontegg-ios-swift#293](https://github.com/frontegg/frontegg-ios-swift/issues/293)) can be
+> set today — the currently pinned `FronteggSwift` ignores unknown plist keys, so it is a safe
+> no-op until a SDK version that supports it ships, at which point it takes effect with no
+> wrapper change. The wrapper also surfaces the key's value to JS via `getConstants().useAssetLinks`
+> (mirroring Android's `useAssetsLinks` BuildConfig constant) so you can verify your configuration.
+
 ### Handle open app with URL
 
 To support login via magic link and other authentication methods that require your app to open from a URL, add the following code to your app.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -90,6 +90,41 @@ export function MyScreen() {
 }
 ```
 
+### Handling login errors
+
+`login()` returns a promise that resolves when login completes, and rejects with a
+`FronteggLoginError` when it fails or the user cancels:
+
+```tsx
+import { login } from '@frontegg/react-native';
+import type { FronteggLoginError } from '@frontegg/react-native';
+
+try {
+  await login();
+} catch (e) {
+  const error = e as FronteggLoginError;
+  if (error.userCancelled) {
+    // the user dismissed the login flow — usually not worth surfacing
+    return;
+  }
+  console.warn(`Login failed (${error.code}): ${error.message}`, error.nativeCode);
+}
+```
+
+The rejection shape is stable across iOS and Android:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `code` | `'user_cancelled' \| 'oauth_failed' \| 'network' \| 'unknown'` | Normalized cross-platform error code. |
+| `message` | `string` | Human-readable message from the native SDK. |
+| `userCancelled` | `boolean` | Convenience flag, `true` when `code === 'user_cancelled'`. |
+| `nativeCode` | `string \| undefined` | Raw platform code — iOS `FronteggError` failure reason (e.g. `operationCanceled`), Android SDK exception class name (e.g. `CanceledByUserException`). |
+| `nativeMessage` | `string \| undefined` | Raw platform message. |
+
+The mapping is conservative: only failures the native layer positively identifies get a
+specific code (`user_cancelled`, `oauth_failed`, `network`); anything else rejects as
+`unknown` with the raw platform details preserved in `nativeCode` / `nativeMessage`.
+
 ## Switch account (tenant)
 
 Use the `switchTenant` function from `useAuth`:

--- a/ios/FronteggRN.swift
+++ b/ios/FronteggRN.swift
@@ -168,10 +168,54 @@ class FronteggRN: RCTEventEmitter {
                 case .failure(let error):
                     // FR-25938: previously resolved "Failed: …", so a cancelled/failed login looked
                     // like success to JS. Reject so the awaited login() rejects.
-                    rejecter(error.failureReason, error.localizedDescription, error)
+                    //
+                    // Issue #110: the old reject code was `error.failureReason`, which is nil for
+                    // the outer FronteggError (only the inner Authentication enum implements it),
+                    // so JS always saw "EUNSPECIFIED". Reject with a stable cross-platform code
+                    // instead, preserving the raw native details in userInfo.
+                    let normalized = Self.normalizedLoginError(error)
+                    let nsError = NSError(
+                        domain: "FronteggRN",
+                        code: 0,
+                        userInfo: [
+                            NSLocalizedDescriptionKey: error.localizedDescription,
+                            "nativeCode": normalized.nativeCode,
+                            "nativeMessage": error.localizedDescription,
+                        ]
+                    )
+                    rejecter(normalized.code, error.localizedDescription, nsError)
                 }
             }
             fronteggApp.auth.login(completion, loginHint:loginHint)
+        }
+    }
+
+    /// Maps a FronteggError from login() onto the stable, cross-platform rejection codes
+    /// documented for the JS `login()` (issue #110). Keep in sync with
+    /// `FronteggLoginErrorCode` in src/FronteggNative.ts and the Android bridge.
+    /// Mapping is conservative: only positively identified failures get a specific
+    /// code; everything else is "unknown" with the raw reason kept in `nativeCode`.
+    private static func normalizedLoginError(_ error: FronteggError) -> (code: String, nativeCode: String) {
+        switch error {
+        case .networkError(let authError):
+            return ("network", authError.failureReason ?? "networkError")
+        case .configError:
+            return ("unknown", "configError")
+        case .authError(let authError):
+            let nativeCode = authError.failureReason ?? "unknown"
+            switch authError {
+            case .operationCanceled:
+                return ("user_cancelled", nativeCode)
+            case .oauthError,
+                 .invalidOAuthState,
+                 .failedToExtractCode,
+                 .codeVerifierNotFound,
+                 .couldNotExchangeToken,
+                 .failedToAuthenticate:
+                return ("oauth_failed", nativeCode)
+            default:
+                return ("unknown", nativeCode)
+            }
         }
     }
     

--- a/ios/FronteggRN.swift
+++ b/ios/FronteggRN.swift
@@ -18,8 +18,29 @@ class FronteggRN: RCTEventEmitter {
             "baseUrl": fronteggApp.baseUrl,
             "clientId": fronteggApp.clientId,
             "applicationId": fronteggApp.applicationId as Any,
-            "bundleId": Bundle.main.bundleIdentifier as Any
+            "bundleId": Bundle.main.bundleIdentifier as Any,
+            "useAssetLinks": Self.plistUseAssetLinks() as Any
         ]
+    }
+
+    /// `useAssetLinks` passthrough (companion to frontegg-ios-swift#293).
+    ///
+    /// iOS configuration is plist-driven: FronteggSwift decodes Frontegg.plist itself, so the
+    /// wrapper has no code path that hands config to native init — the plist *is* the passthrough.
+    /// Unknown keys are ignored by the SDK's Codable decode, so apps can set
+    /// `<key>useAssetLinks</key>` today as a safe no-op; once the pinned FronteggSwift supports
+    /// the key it takes effect with no wrapper change. This reads the same key from the same
+    /// plist so JS can introspect it via getConstants() (parity with Android's `useAssetsLinks`
+    /// BuildConfig constant). Returns nil when the plist or key is absent.
+    private static func plistUseAssetLinks() -> Bool? {
+        guard
+            let url = Bundle.main.url(forResource: "Frontegg", withExtension: "plist"),
+            let data = try? Data(contentsOf: url),
+            let plist = try? PropertyListSerialization.propertyList(from: data, options: [], format: nil) as? [String: Any]
+        else {
+            return nil
+        }
+        return plist["useAssetLinks"] as? Bool
     }
     override func startObserving() {
         self.hasListeners = true

--- a/src/FronteggNative.ts
+++ b/src/FronteggNative.ts
@@ -21,11 +21,100 @@ export function getConstants() {
   return FronteggRN.getConstants();
 }
 
+/**
+ * Stable, cross-platform rejection codes for `login()` (issue #110).
+ *
+ * - `user_cancelled` — the user dismissed/cancelled the login flow.
+ * - `oauth_failed` — the OAuth/hosted-login exchange failed (bad code exchange,
+ *   invalid OAuth state, failed authentication, etc.).
+ * - `network` — a network-level failure was detected by the native SDK.
+ * - `unknown` — anything the wrapper cannot classify; inspect `nativeCode`.
+ *
+ * Mapping is conservative: only failures the native layer can positively
+ * identify get a specific code, everything else is `unknown` with the raw
+ * platform details preserved on `nativeCode` / `nativeMessage`.
+ */
+export type FronteggLoginErrorCode =
+  | 'user_cancelled'
+  | 'oauth_failed'
+  | 'network'
+  | 'unknown';
+
+/** The error `login()` rejects with (issue #110). */
+export interface FronteggLoginError extends Error {
+  code: FronteggLoginErrorCode;
+  message: string;
+  /** Convenience flag, equivalent to `code === 'user_cancelled'`. */
+  userCancelled: boolean;
+  /**
+   * Raw platform error code, preserved for debugging/telemetry:
+   * iOS — `FronteggError` failure reason (e.g. `"operationCanceled"`,
+   * `"couldNotExchangeToken"`); Android — the SDK exception class name
+   * (e.g. `"CanceledByUserException"`).
+   */
+  nativeCode?: string;
+  /** Raw platform error message. */
+  nativeMessage?: string;
+}
+
+const LOGIN_ERROR_CODES: ReadonlyArray<FronteggLoginErrorCode> = [
+  'user_cancelled',
+  'oauth_failed',
+  'network',
+  'unknown',
+];
+
+/**
+ * Normalizes a native `login()` rejection into a `FronteggLoginError`.
+ * The native bridges already reject with the stable codes above; this keeps
+ * the shape guaranteed even for older native layers or unexpected errors.
+ * Exported for testing.
+ */
+export function normalizeLoginError(e: unknown): FronteggLoginError {
+  const raw = (e ?? {}) as {
+    code?: unknown;
+    message?: unknown;
+    userInfo?: { nativeCode?: unknown; nativeMessage?: unknown };
+  };
+  const code: FronteggLoginErrorCode = LOGIN_ERROR_CODES.includes(
+    raw.code as FronteggLoginErrorCode
+  )
+    ? (raw.code as FronteggLoginErrorCode)
+    : 'unknown';
+  const message =
+    typeof raw.message === 'string' && raw.message.length > 0
+      ? raw.message
+      : 'Login failed';
+
+  const error = new Error(message) as FronteggLoginError;
+  error.name = 'FronteggLoginError';
+  error.code = code;
+  error.userCancelled = code === 'user_cancelled';
+  if (typeof raw.userInfo?.nativeCode === 'string') {
+    error.nativeCode = raw.userInfo.nativeCode;
+  } else if (typeof raw.code === 'string' && code === 'unknown') {
+    // Older native layers reject with the raw platform code directly.
+    error.nativeCode = raw.code;
+  }
+  if (typeof raw.userInfo?.nativeMessage === 'string') {
+    error.nativeMessage = raw.userInfo.nativeMessage;
+  }
+  return error;
+}
+
+/**
+ * Opens the Frontegg login flow. Resolves when login completes successfully;
+ * rejects with a {@link FronteggLoginError} when it fails or is cancelled.
+ */
 export async function login(loginHint?: string): Promise<void> {
   // FR-25938: previously fire-and-forget (swallowed the result in console.log), so callers could
   // neither await completion nor observe a cancelled/failed login. Return the promise so it is
   // awaitable and rejections propagate.
-  return FronteggRN.login(loginHint);
+  try {
+    return await FronteggRN.login(loginHint);
+  } catch (e) {
+    throw normalizeLoginError(e);
+  }
 }
 
 export function logout(): Promise<void> {

--- a/src/FronteggNative.ts
+++ b/src/FronteggNative.ts
@@ -17,7 +17,25 @@ const FronteggRN = NativeModules.FronteggRN
       }
     );
 
-export function getConstants() {
+export interface FronteggConstants {
+  baseUrl: string;
+  clientId: string;
+  applicationId?: string | null;
+  bundleId?: string | null;
+  /**
+   * iOS only: the `useAssetLinks` key from `Frontegg.plist`, when present
+   * (companion to frontegg-ios-swift#293 — the wrapper forwards the plist as-is,
+   * so the key reaches the native SDK once it supports it). `null`/`undefined`
+   * when the key is not set or on Android.
+   */
+  useAssetLinks?: boolean | null;
+  /** Android only: `FRONTEGG_USE_ASSETS_LINKS` from the host app's BuildConfig. */
+  useAssetsLinks?: boolean;
+  /** Android only: `FRONTEGG_USE_CHROME_CUSTOM_TABS` from the host app's BuildConfig. */
+  useChromeCustomTabs?: boolean;
+}
+
+export function getConstants(): FronteggConstants {
   return FronteggRN.getConstants();
 }
 

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -1,11 +1,17 @@
 import { NativeModules } from 'react-native';
-import { directLoginAction, openAdminPortal } from '../FronteggNative';
+import {
+  directLoginAction,
+  login,
+  normalizeLoginError,
+  openAdminPortal,
+} from '../FronteggNative';
 
 jest.mock('react-native', () => ({
   NativeModules: {
     FronteggRN: {
       openAdminPortal: jest.fn(() => Promise.resolve(null)),
       directLoginAction: jest.fn(() => Promise.resolve()),
+      login: jest.fn(() => Promise.resolve('Success')),
       subscribe: jest.fn(),
     },
   },
@@ -48,5 +54,75 @@ describe('directLoginAction', () => {
       true,
       undefined
     );
+  });
+});
+
+// Issue #110: login() rejects with a typed, cross-platform FronteggLoginError.
+describe('login', () => {
+  beforeEach(() => {
+    (NativeModules.FronteggRN.login as jest.Mock).mockReset();
+  });
+
+  it('resolves when the native login succeeds', async () => {
+    (NativeModules.FronteggRN.login as jest.Mock).mockResolvedValue('Success');
+    await expect(login('hint@example.com')).resolves.toBe('Success');
+    expect(NativeModules.FronteggRN.login).toHaveBeenCalledWith(
+      'hint@example.com'
+    );
+  });
+
+  it('rejects with a normalized FronteggLoginError carrying the native details', async () => {
+    const nativeError = Object.assign(new Error('Operation canceled by user'), {
+      code: 'user_cancelled',
+      userInfo: {
+        nativeCode: 'operationCanceled',
+        nativeMessage: 'Operation canceled by user',
+      },
+    });
+    (NativeModules.FronteggRN.login as jest.Mock).mockRejectedValue(
+      nativeError
+    );
+
+    await expect(login()).rejects.toMatchObject({
+      name: 'FronteggLoginError',
+      code: 'user_cancelled',
+      userCancelled: true,
+      message: 'Operation canceled by user',
+      nativeCode: 'operationCanceled',
+      nativeMessage: 'Operation canceled by user',
+    });
+  });
+});
+
+describe('normalizeLoginError', () => {
+  it('passes through each stable code and derives userCancelled', () => {
+    for (const code of [
+      'user_cancelled',
+      'oauth_failed',
+      'network',
+      'unknown',
+    ] as const) {
+      const error = normalizeLoginError({ code, message: 'msg' });
+      expect(error.code).toBe(code);
+      expect(error.userCancelled).toBe(code === 'user_cancelled');
+    }
+  });
+
+  it('maps unrecognized codes to unknown, preserving the raw code as nativeCode', () => {
+    const error = normalizeLoginError({
+      code: 'LOGIN_ERROR',
+      message: 'frontegg.error.failed_to_authenticate',
+    });
+    expect(error.code).toBe('unknown');
+    expect(error.userCancelled).toBe(false);
+    expect(error.nativeCode).toBe('LOGIN_ERROR');
+    expect(error.message).toBe('frontegg.error.failed_to_authenticate');
+  });
+
+  it('tolerates null/undefined and non-error rejections', () => {
+    const error = normalizeLoginError(undefined);
+    expect(error.code).toBe('unknown');
+    expect(error.message).toBe('Login failed');
+    expect(error.userCancelled).toBe(false);
   });
 });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -20,6 +20,7 @@ export {
 } from './FronteggNative';
 export type {
   Entitlement,
+  FronteggConstants,
   FronteggLoginError,
   FronteggLoginErrorCode,
 } from './FronteggNative';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -18,4 +18,8 @@ export {
   getFeatureEntitlement,
   getPermissionEntitlement,
 } from './FronteggNative';
-export type { Entitlement } from './FronteggNative';
+export type {
+  Entitlement,
+  FronteggLoginError,
+  FronteggLoginErrorCode,
+} from './FronteggNative';


### PR DESCRIPTION
Implements #110 — a documented, typed error shape for `login()` rejections across platforms — plus companion plumbing for frontegg/frontegg-ios-swift#293.

## What

**Typed login errors (commit 1):**
- TS exports: `FronteggLoginErrorCode` (`'user_cancelled' | 'oauth_failed' | 'network' | 'unknown'`), `FronteggLoginError { code, message, userCancelled, nativeCode?, nativeMessage? }`, `normalizeLoginError()`; `login()` rethrows the normalized shape so consumers get it even against older native layers. Documented in `docs/usage.md`.
- **iOS**: fixes a latent bug — the current `rejecter(error.failureReason, …)` passes nil (`failureReason` only exists on the inner `FronteggError.Authentication` enum), so JS always received `EUNSPECIFIED`. New `normalizedLoginError(_:)` switches on the real error cases (verified against FronteggSwift 1.3.13, the podspec pin): `.operationCanceled → user_cancelled`; the OAuth family → `oauth_failed`; `.networkError → network`; conservative `unknown` otherwise, raw reason preserved in `userInfo`.
- **Android**: the module already forwards the SDK's login callback into the promise (FR-25938) but rejects everything as flat `LOGIN_ERROR`; now normalized — `CanceledByUserException → user_cancelled`, `FailedToAuthenticateException → oauth_failed`, `IOException → network` — with the raw exception class/message preserved.

**useAssetLinks passthrough (commit 2):** the wrapper passes no config to native init (FronteggSwift decodes `Frontegg.plist` itself), so a JS option would be dead plumbing. Instead: `docs/setup.md` documents the plist key as the passthrough (Codable ignores unknown keys today; takes effect automatically if/when #293's native option ships), and `getConstants()` now exposes `useAssetLinks` (typed via a new `FronteggConstants` interface), matching how Android surfaces its config.

## Validation

- `yarn test`: 8/8 (5 new tests covering the normalization paths)
- `yarn typecheck` / eslint: clean vs. baseline (the two `example/` errors and one warning exist identically on master)
- Android: `:frontegg_react-native:testDebugUnitTest` BUILD SUCCESSFUL via `example/android` (module Kotlin + new JVM tests)
- iOS: `swiftc -parse` clean; the error-mapping function additionally typechecked against the real FronteggSwift 1.3.13 error model. A full pod-install host-app build is the remaining verification — draft until we've done that.

One mapping judgment call flagged for review: iOS `.authError(.other(Error))` may wrap URLError network failures; we left it `unknown` (raw reason preserved) rather than guess.
