### PR TITLE
chore(ios): bump FronteggSwift to 1.3.14

### DIFF
--- a/FronteggRN.podspec
+++ b/FronteggRN.podspec
@@ -33,7 +33,7 @@ Pod::Spec.new do |s|
   if defined?(spm_dependency)
     spm_dependency(s,
       url: 'https://github.com/frontegg/frontegg-ios-swift.git',
-      requirement: { kind: 'exactVersion', version: '1.3.13' },
+      requirement: { kind: 'exactVersion', version: '1.3.14' },
       products: ['FronteggSwift']
     )
   end

--- a/ios/Package.swift
+++ b/ios/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     ],
     products: [],
     dependencies: [
-        .package(url: "https://github.com/frontegg/frontegg-ios-swift.git", exact: "1.3.13"),
+        .package(url: "https://github.com/frontegg/frontegg-ios-swift.git", exact: "1.3.14"),
     ],
     targets: []
 )

--- a/ios/frontegg_spm.rb
+++ b/ios/frontegg_spm.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-# Links FronteggSwift (SPM 1.3.13) to the FronteggRN CocoaPods target after `pod install`.
+# Links FronteggSwift (SPM 1.3.14) to the FronteggRN CocoaPods target after `pod install`.
 # Patches Pods.xcodeproj/project.pbxproj as text — xcodeproj gem save() breaks Xcode 26.
 module FronteggSPM
   PACKAGE_URL = 'https://github.com/frontegg/frontegg-ios-swift.git'
-  PACKAGE_VERSION = '1.3.13'
+  PACKAGE_VERSION = '1.3.14'
   PRODUCT_NAME = 'FronteggSwift'
 
   PACKAGE_REF_ID = '2F0A5C48A15A74750BE517A0'


### PR DESCRIPTION
- Updated native SDK to `frontegg-ios-swift` [1.3.14](https://github.com/frontegg/frontegg-ios-swift/releases/tag/1.3.14) (Android unchanged at `1.3.36`, already latest)
- iOS: a failed or cancelled passkey sign-in no longer leaves the embedded login box hanging — error messages containing a quote, backslash or newline previously broke the JavaScript the bridge injected to reject the credential request, so the login page's promise never settled (FR-26113)
- iOS: new opt-in App-Link (https) OAuth redirect — set `useAssetLinks` in `Frontegg.plist` to route the callback through `https://{your-frontegg-domain}/oauth/account/redirect/ios/{bundleId}` instead of the custom URL scheme, matching Android's `useAssetsLinks`. Off by default, and requires iOS 17.4+ — older versions fall back to the custom-scheme callback. Readable from JS via `getConstants()` (FR-26224)

All three iOS integration paths are bumped together so they cannot drift: the `spm_dependency` pin in `FronteggRN.podspec`, the `ios/Package.swift` reference manifest, and `PACKAGE_VERSION` in the `ios/frontegg_spm.rb` fallback. Version-pin change only — no source changes.