### PR TITLE
chore(ios): bump FronteggSwift to 1.3.17

### DIFF
--- a/FronteggRN.podspec
+++ b/FronteggRN.podspec
@@ -33,7 +33,7 @@ Pod::Spec.new do |s|
   if defined?(spm_dependency)
     spm_dependency(s,
       url: 'https://github.com/frontegg/frontegg-ios-swift.git',
-      requirement: { kind: 'exactVersion', version: '1.3.14' },
+      requirement: { kind: 'exactVersion', version: '1.3.17' },
       products: ['FronteggSwift']
     )
   end

--- a/ios/Package.swift
+++ b/ios/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     ],
     products: [],
     dependencies: [
-        .package(url: "https://github.com/frontegg/frontegg-ios-swift.git", exact: "1.3.14"),
+        .package(url: "https://github.com/frontegg/frontegg-ios-swift.git", exact: "1.3.17"),
     ],
     targets: []
 )

--- a/ios/frontegg_spm.rb
+++ b/ios/frontegg_spm.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-# Links FronteggSwift (SPM 1.3.14) to the FronteggRN CocoaPods target after `pod install`.
+# Links FronteggSwift (SPM 1.3.17) to the FronteggRN CocoaPods target after `pod install`.
 # Patches Pods.xcodeproj/project.pbxproj as text — xcodeproj gem save() breaks Xcode 26.
 module FronteggSPM
   PACKAGE_URL = 'https://github.com/frontegg/frontegg-ios-swift.git'
-  PACKAGE_VERSION = '1.3.14'
+  PACKAGE_VERSION = '1.3.17'
   PRODUCT_NAME = 'FronteggSwift'
 
   PACKAGE_REF_ID = '2F0A5C48A15A74750BE517A0'


### PR DESCRIPTION
- Updated native SDKs to `frontegg-ios-swift` [1.3.17](https://github.com/frontegg/frontegg-ios-swift/releases/tag/1.3.17) (`frontegg-android-kotlin` unchanged at 1.3.36)
- iOS: social sign-in no longer fails with a "Failed to get extract code" error after the user has already authenticated with the provider — some values returned by the provider contain characters that must be escaped in a URL and were not being escaped when the SDK built the URL that completes the exchange, so recent iOS versions rejected it and sign-in stopped about a second later. Retrying did not help, and no app or configuration changes are needed to pick up the fix
- iOS: when a social login callback cannot be processed, the SDK now logs the specific reason it was rejected instead of a single generic message
